### PR TITLE
Change the second output of LRN (unit_scale) to be Opaque

### DIFF
--- a/compiler/gradient_ops.cc
+++ b/compiler/gradient_ops.cc
@@ -519,8 +519,8 @@ void BatchNormalizationGradFn(GradientOpContext* gc) {
 void LRNGradFn(GradientOpContext* gc) {
     GraphBuilder gb{gc->builder(0)};
     Node* node = gc->node();
-    Value* unit_scale = gc->AddOutput(Type(gc->x(0)->type()));
-    gc->GradOp(Node::kChainerLRNGrad, 0, {gc->x(0), gc->y(0), gc->gy(0), unit_scale})
+    Value* context = gc->AddOutput(Type(Type::Kind::kOpaque));
+    gc->GradOp(Node::kChainerLRNGrad, 0, {gc->x(0), gc->y(0), gc->gy(0), context})
             ->producer()
             ->set_alpha(node->alpha())
             ->set_beta(node->beta())

--- a/runtime/xcvm_defs.py
+++ b/runtime/xcvm_defs.py
@@ -319,9 +319,9 @@ XC_OPS = [
 
     ('LRN',
      [Array('x'), Float('alpha'), Float('beta'), Float('bias'), Int('size')],
-     ['y', 'unit_scale']),
+     ['y', Opaque('unit_scale')]),
     ('LRNGrad',
-     [Array('x'), Array('y'), Array('gy'), Array('unit_scale'),
+     [Array('x'), Array('y'), Array('gy'), Opaque('ctx'),
       Float('alpha'), Float('beta'), Float('bias'), Int('size')], ['gx']),
 
     ('Equal', [Array('a'), Array('b')], ['c']),


### PR DESCRIPTION
Current construction of gradient parts for LRN node is a little irregular, and it causes some error when recomputation. This PR fixes this issue, though I'm not confident if this method is the best one.