### PR TITLE
Refine gradient generation with computation order

### DIFF
--- a/compiler/gradient_with_order.cc
+++ b/compiler/gradient_with_order.cc
@@ -99,6 +99,10 @@ void AddGradientNodesForTrainingWithOrders(Graph* graph, const std::vector<Order
         CHECK(staged.emplace(value, value).second);
     }
 
+    // A map from the original node to the last forward
+    // computation. This scheduler assumes the last forward
+    // computation is the only computation which must care the
+    // backward computation.
     std::map<Node*, Node*> last_forward_map;
     std::vector<Node*> scheduled_nodes;
     auto schedule_recompute = [&staged, &scheduled_nodes, &last_forward_map](Node* node, Node* orig_node) {
@@ -111,14 +115,12 @@ void AddGradientNodesForTrainingWithOrders(Graph* graph, const std::vector<Order
         }
     };
 
-    auto schedule_node = [&schedule_recompute, &last_forward_map](Node* node) { schedule_recompute(node, node); };
+    auto schedule_node = [&schedule_recompute](Node* node) { schedule_recompute(node, node); };
 
     {
         ScheduleAddedScope schedule_scope(graph, schedule_node);
         SetInitialGradients(graph);
     }
-
-    GraphBuilder gb(graph, "ConnectRetained", graph->output_values()[0]);
 
     std::set<Node*> scheduled_forward;
     for (const Order& order : orders) {
@@ -127,24 +129,34 @@ void AddGradientNodesForTrainingWithOrders(Graph* graph, const std::vector<Order
                 Node* node = order.node;
                 CHECK(node);
                 if (scheduled_forward.insert(node).second) {
+                    // The first forward computation. All inputs must
+                    // be staged and not be recomputed.
                     for (Value* value : node->inputs()) {
                         auto found = staged.find(value);
                         CHECK(found != staged.end()) << value->DebugString();
+                        // Not recomputed.
                         CHECK_EQ(value, found->second);
                     }
                     schedule_node(node);
                 } else {
+                    // All inputs must be staged and may be recomputed.
                     std::vector<Value*> inputs;
                     for (Value* value : node->inputs()) {
                         auto found = staged.find(value);
                         CHECK(found != staged.end());
                         inputs.push_back(found->second);
                     }
+
+                    // Recomputed values need different `Value`
+                    // objects with different names.
                     std::vector<Value*> outputs;
                     for (Value* value : node->outputs()) {
                         Value* new_value = graph->AddValue("Recompute" + value->name());
                         outputs.push_back(new_value);
                     }
+
+                    // Copy the original computation node to generate
+                    // node for recomputation.
                     onnx::NodeProto xnode;
                     node->ToONNX(&xnode);
                     Node* new_node = new Node(xnode, inputs, outputs);
@@ -160,6 +172,8 @@ void AddGradientNodesForTrainingWithOrders(Graph* graph, const std::vector<Order
                 CHECK(found != last_forward_map.end());
                 Node* node = found->second;
 
+                // Copy gradients of outputs from the original
+                // computation node to the last forward computation.
                 if (node != orig_node) {
                     for (const auto& p : Zip(node->outputs(), orig_node->outputs())) {
                         std::get<0>(p)->set_grad(std::get<1>(p)->grad());
@@ -172,6 +186,8 @@ void AddGradientNodesForTrainingWithOrders(Graph* graph, const std::vector<Order
                     // CHECK(false) << "All ops must be differentiable: " << node->DebugString();
                 }
 
+                // Copy back gradients of inputs from the last forward
+                // computation to the original node.
                 if (node != orig_node) {
                     for (const auto& p : Zip(orig_node->inputs(), node->inputs())) {
                         std::get<0>(p)->set_grad(std::get<1>(p)->grad());


### PR DESCRIPTION
Before this change, modifying forward computation was always done for the first forward computation. After this change however, the modification is done for the last forward computation, the only forward computation which actually must run in "training mode".
