### PR TITLE
Large testcase

### DIFF
--- a/scripts/gen_large_tests_oc.py
+++ b/scripts/gen_large_tests_oc.py
@@ -1,0 +1,47 @@
+#!/usr/bin/python3
+
+import chainer
+import numpy as np
+import onnx_chainer
+
+import large_models
+
+
+def create_backprop_test(test_name, get_fun, dtype):
+    test_dir = 'out/large_test_oc_%s' % test_name
+
+    np.random.seed(314)
+    chainer.config.dtype = dtype
+
+    model, inputs = get_fun(dtype)
+    output_grad = dtype == np.float64
+
+    chainer.disable_experimental_feature_warning = True
+    onnx_chainer.export_testcase(model,
+                                 inputs,
+                                 test_dir,
+                                 output_grad=output_grad,
+                                 train=True,
+                                 output_names='loss')
+
+
+def get_backprop_tests():
+    tests = []
+
+    def test(name, get_fun):
+        for dtype in (np.float32, np.float64):
+            test_name = '%s_%s' % (name, dtype.__name__)
+            tests.append((test_name, get_fun, dtype))
+
+    test('resnet50', large_models.get_resnet50)
+
+    return tests
+
+
+def main():
+    for test in get_backprop_tests():
+        create_backprop_test(*test)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/gen_large_tests_oc.py
+++ b/scripts/gen_large_tests_oc.py
@@ -37,6 +37,9 @@ def get_large_tests():
             tests.append((test_name, get_fun, dtype))
 
     test('resnet50', large_models.get_resnet50)
+    test('resnet152', large_models.get_resnet152)
+    # test('vgg16', large_models.get_vgg16)
+    # test('vgg19', large_models.get_vgg19)
 
     return tests
 

--- a/scripts/large_models/__init__.py
+++ b/scripts/large_models/__init__.py
@@ -1,0 +1,1 @@
+from large_models.resnet import get_resnet50  # noqa

--- a/scripts/large_models/__init__.py
+++ b/scripts/large_models/__init__.py
@@ -1,1 +1,4 @@
-from large_models.resnet import get_resnet50  # noqa
+from large_models.chainer_chain import get_resnet50  # noqa
+from large_models.chainer_chain import get_resnet152  # noqa
+from large_models.chainer_chain import get_vgg16  # noqa
+from large_models.chainer_chain import get_vgg19  # noqa

--- a/scripts/large_models/chainer_chain.py
+++ b/scripts/large_models/chainer_chain.py
@@ -22,10 +22,25 @@ class Wrapper(chainer.Chain):
         return y
 
 
-def get_resnet50(dtype=None):
+def get_chainer_model(chainer_chain, dtype, key):
     batchsize = 4
     x = np.random.uniform(size=(batchsize, 3, 224, 224)).astype(dtype)
     t = np.random.randint(size=(batchsize,), low=0, high=1000).astype(np.int32)
-    model = Wrapper(L.ResNet50Layers(pretrained_model=None),
-                    'fc6')
+    model = Wrapper(chainer_chain(pretrained_model=None), key)
     return model, [x, t]
+
+
+def get_resnet50(dtype=None):
+    return get_chainer_model(L.ResNet50Layers, dtype, 'fc6')
+
+
+def get_resnet152(dtype=None):
+    return get_chainer_model(L.ResNet152Layers, dtype, 'fc6')
+
+
+def get_vgg16(dtype=None):
+    return get_chainer_model(L.VGG16Layers, dtype, 'fc8')
+
+
+def get_vgg19(dtype=None):
+    return get_chainer_model(L.VGG19Layers, dtype, 'fc8')

--- a/scripts/large_models/resnet.py
+++ b/scripts/large_models/resnet.py
@@ -1,0 +1,31 @@
+import chainer
+import chainer.functions as F
+import chainer.links as L
+import numpy as np
+
+
+class Wrapper(chainer.Chain):
+
+    def __init__(self, predictor, key=None):
+        super().__init__()
+
+        with self.init_scope():
+            self.predictor = predictor
+        self.key = key
+
+    def __call__(self, x, t):
+        if self.key is None:
+            y = self.predictor(x)
+        else:
+            y = self.predictor(x, layers=[self.key])[self.key]
+        y = F.softmax_cross_entropy(y, t)
+        return y
+
+
+def get_resnet50(dtype=None):
+    batchsize = 4
+    x = np.random.uniform(size=(batchsize, 3, 224, 224)).astype(dtype)
+    t = np.random.randint(size=(batchsize,), low=0, high=1000).astype(np.int32)
+    model = Wrapper(L.ResNet50Layers(pretrained_model=None),
+                    'fc6')
+    return model, [x, t]

--- a/scripts/runtests.py
+++ b/scripts/runtests.py
@@ -14,6 +14,7 @@ import elichika_tests
 import gen_backprop_tests_oc
 import gen_backprop_tests_pc
 import gen_extra_test
+import gen_large_tests_oc
 import onnx_chainer_tests
 import onnx_real_tests
 from test_case import TestCase
@@ -540,6 +541,10 @@ for test in gen_extra_test.get_tests():
     assert os.path.exists(test.test_dir)
     TEST_CASES.append(test)
 
+for name, _, _ in gen_large_tests_oc.get_large_tests():
+    dirname = 'out'
+    TEST_CASES.append(TestCase(dirname, name, want_gpu=True))
+
 TEST_CASES.append(TestCase('out', 'backprop_test_mnist_mlp'))
 
 TEST_CASES.append(TestCase('data', 'resnet50', want_gpu=True))
@@ -557,10 +562,12 @@ for test in TEST_CASES:
     if not test.is_backprop:
         continue
 
-    new_test = copy.copy(test)
-    new_test.name = test.name + '_two_phase'
-    new_test.is_backprop_two_phase = True
-    new_tests.append(new_test)
+    # TODO(mkusumoto): remove this "if" after fixing issue
+    if not test.name.startswith('large_oc'):
+        new_test = copy.copy(test)
+        new_test.name = test.name + '_two_phase'
+        new_test.is_backprop_two_phase = True
+        new_tests.append(new_test)
 
     if test.name == 'ch2o_model_MLP_with_loss_backprop':
         new_test = copy.copy(test)


### PR DESCRIPTION
I'm adding large test cases that are generated by `onnx-chainer`. This can be used in `runtests.py` when `--use_gpu` flag is specified.
I noticed that this test fails when `two_phase_backprop` option is employed in `runtests.py`. Probably we need to investigate the reason for this.