### PR TITLE
in_recomputing flag for BN

### DIFF
--- a/compiler/gen_node.py
+++ b/compiler/gen_node.py
@@ -179,7 +179,7 @@ NodeDef('ConvTranspose', (2, 3), 1,
 
 # Extension: the second or the sixth output is for backward context.
 NodeDef('BatchNormalization', 5, (1, 2, 3, 4, 5, 6),
-        epsilon=1e-5, momentum=0.9, spatial=1)
+        epsilon=1e-5, momentum=0.9, spatial=1, chainer_in_recomputing=0)
 # Extension: the second output is for backward context.
 NodeDef('LRN', 1, (1, 2), alpha=1e-4, beta=0.75, bias=1.0, size=Required(int))
 NodeDef('LpNormalization', 1, 1, axis=-1, p=2)

--- a/compiler/gradient_with_order.cc
+++ b/compiler/gradient_with_order.cc
@@ -177,9 +177,9 @@ void AddGradientNodesForTrainingWithOrders(Graph* graph, const std::vector<Order
                     Node* new_node = new Node(xnode, inputs, outputs);
                     graph->AddNodeImpl(std::unique_ptr<Node>(new_node), inputs, outputs);
                     schedule_recompute(new_node, node);
-		    if (node->op_type() == Node::kBatchNormalization) {
-			node->set_chainer_in_recomputing(1);
-		    }
+                    if (node->op_type() == Node::kBatchNormalization) {
+                        node->set_chainer_in_recomputing(1);
+                    }
                 }
                 break;
             }

--- a/compiler/gradient_with_order.cc
+++ b/compiler/gradient_with_order.cc
@@ -177,6 +177,9 @@ void AddGradientNodesForTrainingWithOrders(Graph* graph, const std::vector<Order
                     Node* new_node = new Node(xnode, inputs, outputs);
                     graph->AddNodeImpl(std::unique_ptr<Node>(new_node), inputs, outputs);
                     schedule_recompute(new_node, node);
+		    if (node->op_type() == Node::kBatchNormalization) {
+			node->set_chainer_in_recomputing(1);
+		    }
                 }
                 break;
             }

--- a/compiler/xcvm/emitter.cc
+++ b/compiler/xcvm/emitter.cc
@@ -715,7 +715,7 @@ private:
         CHECK_EQ(5UL, node.inputs().size());
         CHECK_EQ(1, node.spatial()) << "`spatial` for BatchNormalization was removed from ONNX";
         size_t num_onnx_outputs = node.outputs().size();
-        if (num_onnx_outputs == 1) {
+        if (num_onnx_outputs == 1 && !node.chainer_in_recomputing()) {
             EMIT(FixedBatchNormalization,
                  GetOutputValue(node, 0),
                  GetValueId(node.input(0)),

--- a/compiler/xcvm/emitter.cc
+++ b/compiler/xcvm/emitter.cc
@@ -715,7 +715,7 @@ private:
         CHECK_EQ(5UL, node.inputs().size());
         CHECK_EQ(1, node.spatial()) << "`spatial` for BatchNormalization was removed from ONNX";
         size_t num_onnx_outputs = node.outputs().size();
-        if (num_onnx_outputs == 1 && !node.chainer_in_recomputing()) {
+        if (num_onnx_outputs == 1) {
             EMIT(FixedBatchNormalization,
                  GetOutputValue(node, 0),
                  GetValueId(node.input(0)),

--- a/compiler/xcvm/emitter.cc
+++ b/compiler/xcvm/emitter.cc
@@ -755,7 +755,7 @@ private:
              GetValueId(node.input(4)),
              node.epsilon(),
              node.momentum(),
-	     node.chainer_in_recomputing());
+             node.chainer_in_recomputing());
     }
 
 #undef EMIT

--- a/compiler/xcvm/emitter.cc
+++ b/compiler/xcvm/emitter.cc
@@ -715,7 +715,7 @@ private:
         CHECK_EQ(5UL, node.inputs().size());
         CHECK_EQ(1, node.spatial()) << "`spatial` for BatchNormalization was removed from ONNX";
         size_t num_onnx_outputs = node.outputs().size();
-        if (num_onnx_outputs == 1) {
+        if (num_onnx_outputs == 1 && !node.chainer_in_recomputing()) {
             EMIT(FixedBatchNormalization,
                  GetOutputValue(node, 0),
                  GetValueId(node.input(0)),
@@ -754,7 +754,8 @@ private:
              GetValueId(node.input(3)),
              GetValueId(node.input(4)),
              node.epsilon(),
-             node.momentum());
+             node.momentum(),
+	     node.chainer_in_recomputing());
     }
 
 #undef EMIT

--- a/runtime/ops/normalization.cc
+++ b/runtime/ops/normalization.cc
@@ -124,6 +124,7 @@ std::tuple<chainerx::Array, XCVMOpaque*, chainerx::Array, chainerx::Array, chain
 
     PreprocessBatchNormResult result;
     if (in_recomputing) {
+        // Statistics shouldn't be updated when recomputing
         result = PreprocessBatchNorm(x, s, bias, mean.Copy(), var.Copy(), axes);
     } else {
         result = PreprocessBatchNorm(x, s, bias, mean, var, axes);

--- a/runtime/ops/normalization.cc
+++ b/runtime/ops/normalization.cc
@@ -115,7 +115,6 @@ std::tuple<chainerx::Array, XCVMOpaque*, chainerx::Array, chainerx::Array, chain
         const chainerx::Array& bias,
         const chainerx::Array& mean,
         const chainerx::Array& var) {
-    // TODO(hamaji): Use `in_recomputing` not to update running mean/var.
     // To workaround the limitation of CuDNN.
     if (epsilon <= 1e-5) epsilon = 1e-5 + 1e-12;
     chainerx::Axes axes;
@@ -128,7 +127,20 @@ std::tuple<chainerx::Array, XCVMOpaque*, chainerx::Array, chainerx::Array, chain
             x.device().GetBatchNormForwardBackward(result.mean, result.var, epsilon, decay, result.sorted_axis);
     const Array& gamma_reshaped = result.gamma;
     const Array& beta_reshaped = result.beta;
+
+    chainerx::Array mean_copy, var_copy;  // We used these only for in_recomputing mode
+    if (in_recomputing) {
+        mean_copy = mean.Copy();
+        var_copy = var.Copy();
+    }
     chainerx::Array out = fb->Forward(x, gamma_reshaped, beta_reshaped);
+    if (in_recomputing) {
+        // Revert the statistics
+        mean *= chainerx::Scalar(0);
+        mean += mean_copy;
+        var *= chainerx::Scalar(0);
+        var += var_copy;
+    }
     XCVMOpaque* ctx = new BatchNormBackwardContext(std::move(fb), s.shape(), bias.shape());
     if (st->options().dump_memory_usage) {
         ctx->SetRetainedArrays({x, gamma_reshaped, beta_reshaped, result.mean, result.var});

--- a/runtime/ops/normalization.cc
+++ b/runtime/ops/normalization.cc
@@ -115,6 +115,7 @@ std::tuple<chainerx::Array, XCVMOpaque*, chainerx::Array, chainerx::Array, chain
         const chainerx::Array& bias,
         const chainerx::Array& mean,
         const chainerx::Array& var) {
+    // TODO(hamaji): Use `in_recomputing` not to update running mean/var.
     // To workaround the limitation of CuDNN.
     if (epsilon <= 1e-5) epsilon = 1e-5 + 1e-12;
     chainerx::Axes axes;

--- a/runtime/xcvm_defs.py
+++ b/runtime/xcvm_defs.py
@@ -321,7 +321,7 @@ XC_OPS = [
 
     ('BatchNormalization',
      [Array('x'), Array('s'), Array('bias'), Array('mean'), Array('var'),
-      Float('epsilon'), Float('decay')],
+      Float('epsilon'), Float('decay'), Int('in_recomputing')],
      ['y', Opaque('ctx'),
       OptionalArray('running_mean'), OptionalArray('running_var'),
       OptionalArray('saved_mean'), OptionalArray('saved_var')]),


### PR DESCRIPTION
This PR will prevent from updating batch normalization statistics more than once when recomputation is performed.
Currently, there is no test for checking the statistics. I just verified the result by manually putting `std::cout << var << std::endl;` in the intermediate of the code and seeing the values.