### PR TITLE
Fixed Dockerfile

### DIFF
--- a/docker/Dockerfile.tmpl
+++ b/docker/Dockerfile.tmpl
@@ -25,7 +25,6 @@ RUN apt-get update -y && \
     protobuf-compiler \
     python3-dev \
     python3-pip \
-    python3-pytest \
     python3-setuptools \
     python3-wheel \
     unzip \
@@ -37,7 +36,7 @@ RUN apt-get update -y && \
 
 RUN CHAINER_BUILD_CHAINERX=1 CHAINERX_BUILD_CUDA=1 pip3 install --no-cache-dir cupy-cuda100==6.0.0b1 chainer==6.0.0b1
 
-RUN pip3 install gast numpy chainer onnx==1.3.0 onnx_chainer matplotlib Pillow xgboost tornado psutil
+RUN pip3 install gast numpy chainer onnx==1.3.0 onnx_chainer matplotlib Pillow xgboost tornado psutil pytest
 
 COPY tvm_install/ubuntu_install_core.sh /install/ubuntu_install_core.sh
 RUN bash /install/ubuntu_install_core.sh

--- a/docker/Dockerfile.tmpl
+++ b/docker/Dockerfile.tmpl
@@ -36,7 +36,7 @@ RUN apt-get update -y && \
 
 RUN CHAINER_BUILD_CHAINERX=1 CHAINERX_BUILD_CUDA=1 pip3 install --no-cache-dir cupy-cuda100==6.0.0b1 chainer==6.0.0b1
 
-RUN pip3 install gast numpy chainer onnx==1.3.0 onnx_chainer matplotlib Pillow xgboost tornado psutil pytest
+RUN pip3 install gast numpy chainer onnx==1.3.0 onnx_chainer onnxruntime matplotlib Pillow xgboost tornado psutil pytest
 
 COPY tvm_install/ubuntu_install_core.sh /install/ubuntu_install_core.sh
 RUN bash /install/ubuntu_install_core.sh


### PR DESCRIPTION
I cannot build docker image using Dockerfile.tmpl, so fixed it.
Since the following pip3 installations are lacked likely, they are added in this PR.

- onnxruntime
- pytest
