### PR TITLE
Fixed 4 issues of type: PYTHON_E225 throughout 1 file in repo.

### DIFF
--- a/elichika/elichika/chainer2onnx.py
+++ b/elichika/elichika/chainer2onnx.py
@@ -67,7 +67,7 @@ def generate_onnx_value_name(value : 'values.Value', none_name = ''):
         name = 'noname'
 
     while (name in assigned_names):
-        ind+=1
+        ind += 1
         name = base_name + '_' + str(ind)
 
     assigned_names.append(name)
@@ -79,7 +79,7 @@ def generate_onnx_node_name(node : 'nodes.Node'):
     ind = 0
     name = base_name
     while (name in assigned_names):
-        ind+=1
+        ind += 1
         name = base_name + '_' + str(ind)
 
     assigned_names.append(name)
@@ -92,7 +92,7 @@ def generate_onnx_name(name : 'str'):
     ind = 0
     name = base_name
     while (name in assigned_names):
-        ind+=1
+        ind += 1
         name = base_name + '_' + str(ind)
 
     assigned_names.append(name)
@@ -1102,7 +1102,7 @@ class ONNXGenerator:
 
         return onnx_graph.generate_graph(graph.name, isMain=isMain)
 
-    def generate_model(self, inputs, outputs, graph, model)-> 'ModelProto':
+    def generate_model(self, inputs, outputs, graph, model) -> 'ModelProto':
 
         # assign param names
         self.param2name = {id(p): 'param' + n.replace('/', '_')


### PR DESCRIPTION
PYTHON_E225: 'Fix extraneous whitespace around keywords.'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.