### PR TITLE
Skip test case with computation_order if dyamic shape is used

### DIFF
--- a/compiler/gradient_with_order.cc
+++ b/compiler/gradient_with_order.cc
@@ -133,8 +133,8 @@ void AddRetainedParts(Graph* fwd_graph, Graph* bwd_graph, std::map<Value*, Value
 }
 
 bool IsComputationOrderSupported(const Graph& graph) {
-    for (const auto& value_ptr : graph.all_values()) {
-        if (value_ptr.get()->type().GetNBytes() < 0) {
+    for (auto* value : graph.GetNecessaryValues()) {
+        if (value->type().GetNBytes() < 0) {
             return false;
         }
     }

--- a/compiler/gradient_with_order.h
+++ b/compiler/gradient_with_order.h
@@ -10,8 +10,8 @@ class Order;
 
 std::vector<Order> GetComputationOrder(const Graph& graph, const std::string& policy);
 
-void AddGradientNodesForTrainingWithOrders(Graph* graph, const std::vector<Order>& orders);
+bool AddGradientNodesForTrainingWithOrders(Graph* graph, const std::vector<Order>& orders);
 
-void AddGradientNodesForTrainingWithOrders(Graph* fwd_graph, Graph* bwd_graph, const std::vector<Order>& orders);
+bool AddGradientNodesForTrainingWithOrders(Graph* fwd_graph, Graph* bwd_graph, const std::vector<Order>& orders);
 
 }  // namespace chainer_compiler

--- a/compiler/passes.cc
+++ b/compiler/passes.cc
@@ -113,6 +113,7 @@ void RunDefaultPasses(Graph* graph, bool gen_backprop) {
             auto orders = GetComputationOrder(*graph, g_computation_order);
             if (!AddGradientNodesForTrainingWithOrders(graph, orders)) {
                 std::cerr << "Computation order is not supported in this graph.\n";
+                // TODO(mkusumoto): don't exit here
                 exit(0);
             }
             // SimplifyOps({Node::kIdentity}, graph);

--- a/compiler/passes.cc
+++ b/compiler/passes.cc
@@ -111,7 +111,10 @@ void RunDefaultPasses(Graph* graph, bool gen_backprop) {
             // specified computation order
             skip_scheduling = true;
             auto orders = GetComputationOrder(*graph, g_computation_order);
-            AddGradientNodesForTrainingWithOrders(graph, orders);
+            if (!AddGradientNodesForTrainingWithOrders(graph, orders)) {
+                std::cerr << "Computation order is not supported in this graph.\n";
+                exit(0);
+            }
             // SimplifyOps({Node::kIdentity}, graph);
         }
     }

--- a/tools/run_onnx.cc
+++ b/tools/run_onnx.cc
@@ -242,6 +242,7 @@ public:
                 auto orders = GetComputationOrder(model->graph(), g_computation_order);
                 if (!AddGradientNodesForTrainingWithOrders(model->mutable_graph(), backprop_model.mutable_graph(), orders)) {
                     LOG() << "Computation order is not supported in this graph." << std::endl;
+                    // TODO(mkusumoto): don't exit here
                     exit(0);
                 }
             }

--- a/tools/run_onnx.cc
+++ b/tools/run_onnx.cc
@@ -240,7 +240,10 @@ public:
                 GenerateGradientNodes(model->mutable_graph(), backprop_model.mutable_graph());
             } else {
                 auto orders = GetComputationOrder(model->graph(), g_computation_order);
-                AddGradientNodesForTrainingWithOrders(model->mutable_graph(), backprop_model.mutable_graph(), orders);
+                if (!AddGradientNodesForTrainingWithOrders(model->mutable_graph(), backprop_model.mutable_graph(), orders)) {
+                    LOG() << "Computation order is not supported in this graph." << std::endl;
+                    exit(0);
+                }
             }
             // TODO(hamaji): Revive shape inference.
             g_skip_inference = true;


### PR DESCRIPTION
Several tests will be skipped in runtests.py with computation_order flag.