### PR TITLE
Testing computation_order flag in CI

### DIFF
--- a/compiler/passes.cc
+++ b/compiler/passes.cc
@@ -113,11 +113,8 @@ void RunDefaultPasses(Graph* graph, bool gen_backprop, bool skip_scheduling) {
             skip_scheduling = true;
             auto orders = GetComputationOrder(*graph, g_computation_order);
             if (!AddGradientNodesForTrainingWithOrders(graph, orders)) {
-                std::cerr << "Computation order is not supported in this graph.\n";
-                // TODO(mkusumoto): don't exit here
-                exit(0);
+                CHECK(false) << "Computation order is not supported in this graph.";
             }
-            // SimplifyOps({Node::kIdentity}, graph);
         }
     }
 

--- a/scripts/runtests.py
+++ b/scripts/runtests.py
@@ -591,11 +591,18 @@ for test in TEST_CASES:
         new_test.is_backprop_two_phase = True
         new_tests.append(new_test)
 
-    if test.name == 'ch2o_model_MLP_with_loss_backprop':
+    # computation_order is supported in limited test cases
+    if test.name.startswith('backprop_test_oc'):
         new_test = copy.copy(test)
         new_test.name = test.name + '_computation_order'
         new_test.computation_order = 'dummy'
         new_tests.append(new_test)
+
+        new_test2 = copy.copy(test)
+        new_test2.name = test.name + '_computation_order_two_phase'
+        new_test2.computation_order = 'dummy'
+        new_test2.is_backprop_two_phase = True
+        new_tests.append(new_test2)
 
 for test in new_tests:
     TEST_CASES.append(test)

--- a/tools/run_onnx.cc
+++ b/tools/run_onnx.cc
@@ -242,9 +242,7 @@ public:
             } else {
                 auto orders = GetComputationOrder(model->graph(), g_computation_order);
                 if (!AddGradientNodesForTrainingWithOrders(model->mutable_graph(), backprop_model.mutable_graph(), orders)) {
-                    LOG() << "Computation order is not supported in this graph." << std::endl;
-                    // TODO(mkusumoto): don't exit here
-                    exit(0);
+                    CHECK(false) << "Computation order is not supported in this graph.";
                 }
                 skip_scheduling = true;
             }


### PR DESCRIPTION
This PR adds test cases with computation_order flag to `runtests.py` by default.