### PR TITLE
Let compiler depend on gen_onnx_operators_proto

### DIFF
--- a/compiler/CMakeLists.txt
+++ b/compiler/CMakeLists.txt
@@ -79,7 +79,8 @@ add_library(chainer_compiler_compiler
   )
 add_dependencies(
   chainer_compiler_compiler
-  runtime_xcvm_pb_h compiler_xcvm_codegen_h gen_node_base_h gen_onnx_proto
+  runtime_xcvm_pb_h compiler_xcvm_codegen_h gen_node_base_h
+  gen_onnx_proto gen_onnx_operators_proto
   )
 set_hidden_(chainer_compiler_compiler)
 


### PR DESCRIPTION
It indirectly depends on onnx-operators.proto via
custom_onnx_ops.cc.