### PR TITLE
Fix to support data directory on runtest script

### DIFF
--- a/scripts/test_case.py
+++ b/scripts/test_case.py
@@ -36,7 +36,8 @@ class TestCase(object):
         self.backend = backend
 
         self.log_dirname = self.test_dir
-        if not self.log_dirname.startswith('out'):
+        if not (self.log_dirname.startswith('out') or
+                self.log_dirname.startswith('data')):
             self.log_dirname = os.path.join('out', name)
             makedirs(self.log_dirname)
         self.log_filename = os.path.join(self.log_dirname, 'out.txt')


### PR DESCRIPTION
I got an error message

```
Traceback (most recent call last):
  File "scripts/runtests.py", line 790, in <module>
    main()
  File "scripts/runtests.py", line 771, in main
    runner.run(num_jobs)
  File "scripts/runtests.py", line 654, in run
    log_file = open(test_case.log_filename, 'wb')
FileNotFoundError: [Errno 2] No such file or directory: 'out/resnet50/out.txt'
```

I don't know this fix is the best.