### PR TITLE
Fix computation order

### DIFF
--- a/compiler/computation_order/core.cc
+++ b/compiler/computation_order/core.cc
@@ -2,19 +2,24 @@
 
 namespace chainer_compiler {
 
+const char* GREEN = "\033[92m";
+const char* YELLOW = "\033[93m";
+const char* RED = "\033[91m";
+const char* RESET = "\033[0m";
+
 std::ostream& operator<<(std::ostream& os, const Order& order) {
     os << "Order: ";
     switch (order.kind) {
         case Order::kComputeForward: {
-            os << "ComputeForward(node=" << order.node->ToString() << ")";
+            os << GREEN << "ComputeForward" << RESET << "(node=" << order.node->ToString() << ")";
             break;
         }
         case Order::kComputeBackward: {
-            os << "ComputeBackward(node=" << order.node->ToString() << ")";
+            os << YELLOW << "ComputeBackward" << RESET << "(node=" << order.node->ToString() << ")";
             break;
         }
         case Order::kForgetForward: {
-            os << "ForgetForward(value=" << order.value->name() << ")";
+            os << RED << "ForgetForward" << RESET << "(value=" << order.value->name() << ")";
             break;
         }
         case Order::kForgetBackward: {

--- a/compiler/computation_order/policy_chen.cc
+++ b/compiler/computation_order/policy_chen.cc
@@ -135,7 +135,6 @@ std::vector<Order> ChenPolicy(const Graph& graph) {
             }
         }
     }
-    for (auto s : must_remember) std::cout << "Must remember " << s->ToString() << std::endl;
 
     // Perform forward propagation with forgetting
     size_t last_split = 0;
@@ -166,7 +165,6 @@ std::vector<Order> ChenPolicy(const Graph& graph) {
     size_t end_index = sorted.size();
     for (int64_t i = static_cast<int64_t>(split_indices.size()) - 1; i >= -1; --i) {
         int64_t begin_index = (i >= 0) ? (static_cast<int64_t>(split_indices[i]) + (i >= 0)) : 0;
-        std::cout << "####" << begin_index << " " << end_index << std::endl;
 
         for (int64_t j = begin_index; j < end_index; ++j) {
             // recomputation for [begin_index, end_index)

--- a/compiler/computation_order/policy_dummy.cc
+++ b/compiler/computation_order/policy_dummy.cc
@@ -50,6 +50,9 @@ std::vector<Order> DummyPolicy2(const Graph& graph) {
             }
         }
     }
+    for (auto value : nodes.back()->outputs()) {
+        orders.emplace_back(Order::kForgetForward, nullptr, value);
+    }
     for (auto node : nodes) {
         orders.emplace_back(Order::kComputeForward, node, nullptr);
     }

--- a/compiler/gradient_with_order.cc
+++ b/compiler/gradient_with_order.cc
@@ -141,8 +141,7 @@ bool IsComputationOrderSupported(const Graph& graph) {
     return true;
 }
 
-std::vector<Value*> GetStagedValues(const std::map<Value*, Value*>& staged,
-                                    const std::vector<Value*>& values) {
+std::vector<Value*> GetStagedValues(const std::map<Value*, Value*>& staged, const std::vector<Value*>& values) {
     std::vector<Value*> ret;
     for (Value* value : values) {
         auto found = staged.find(value);
@@ -280,7 +279,8 @@ bool AddGradientNodesForTrainingWithOrders(Graph* fwd_graph, Graph* bwd_graph, c
                 const std::vector<Value*> inputs = node->inputs();
                 const std::vector<Value*> outputs = node->outputs();
                 const std::vector<Value*> staged_inputs = GetStagedValues(staged, orig_node->inputs());
-                const std::vector<Value*> staged_outputs = GetStagedValues(staged, orig_node->outputs());;
+                const std::vector<Value*> staged_outputs = GetStagedValues(staged, orig_node->outputs());
+                ;
                 for (const auto& p : Zip(inputs, staged_inputs)) {
                     node->ReplaceInput(std::get<0>(p), std::get<1>(p));
                     std::get<0>(p)->DetachUser(node);

--- a/compiler/gradient_with_order.cc
+++ b/compiler/gradient_with_order.cc
@@ -260,8 +260,14 @@ bool AddGradientNodesForTrainingWithOrders(Graph* fwd_graph, Graph* bwd_graph, c
                 // computation node to the last forward computation.
                 // Copying inputs is necessary to accumulate gradients.
                 if (node != orig_node) {
+                    for (Value* input : node->inputs()) {
+                        CHECK(!input->grad()) << "the gradient of input should be empty: " << input->DebugString();
+                    }
+                    for (Value* input : orig_node->inputs()) {
+                        CHECK(!input->grad()) << "the gradient of input should be empty: " << input->DebugString();
+                    }
                     for (const auto& p : Zip(node->inputs(), orig_node->inputs())) {
-                        std::get<0>(p)->set_grad(std::get<1>(p)->grad());
+                        // std::get<0>(p)->set_grad(std::get<1>(p)->grad());
                     }
                     for (const auto& p : Zip(node->outputs(), orig_node->outputs())) {
                         std::get<0>(p)->set_grad(std::get<1>(p)->grad());
@@ -295,10 +301,8 @@ bool AddGradientNodesForTrainingWithOrders(Graph* fwd_graph, Graph* bwd_graph, c
 
                 // Copy back gradients of inputs from the last forward
                 // computation to the original node.
-                if (node != orig_node) {
-                    for (const auto& p : Zip(orig_node->inputs(), node->inputs())) {
-                        std::get<0>(p)->set_grad(std::get<1>(p)->grad());
-                    }
+                for (const auto& p : Zip(orig_node->inputs(), staged_inputs)) {
+                    std::get<0>(p)->set_grad(std::get<1>(p)->grad());
                 }
 
                 break;

--- a/compiler/gradient_with_order.cc
+++ b/compiler/gradient_with_order.cc
@@ -175,7 +175,7 @@ bool AddGradientNodesForTrainingWithOrders(Graph* fwd_graph, Graph* bwd_graph, c
         for (const auto& p : Zip(node->outputs(), orig_node->outputs())) {
             Value* value = std::get<0>(p);
             if (!staged.emplace(std::get<1>(p), value).second) {
-                std::cerr << "Forward recompute without forgetting the output: " << orig_node->ToString() << std::endl;
+                CHECK(false) << "Forward recompute without forgetting the output: " << orig_node->ToString();
             }
         }
     };

--- a/compiler/gradient_with_order.cc
+++ b/compiler/gradient_with_order.cc
@@ -260,14 +260,8 @@ bool AddGradientNodesForTrainingWithOrders(Graph* fwd_graph, Graph* bwd_graph, c
                 // computation node to the last forward computation.
                 // Copying inputs is necessary to accumulate gradients.
                 if (node != orig_node) {
-                    for (Value* input : node->inputs()) {
-                        CHECK(!input->grad()) << "the gradient of input should be empty: " << input->DebugString();
-                    }
-                    for (Value* input : orig_node->inputs()) {
-                        CHECK(!input->grad()) << "the gradient of input should be empty: " << input->DebugString();
-                    }
                     for (const auto& p : Zip(node->inputs(), orig_node->inputs())) {
-                        // std::get<0>(p)->set_grad(std::get<1>(p)->grad());
+                        std::get<0>(p)->set_grad(std::get<1>(p)->grad());
                     }
                     for (const auto& p : Zip(node->outputs(), orig_node->outputs())) {
                         std::get<0>(p)->set_grad(std::get<1>(p)->grad());


### PR DESCRIPTION
This PR fixes Chen's computation order policy that was not correct before.
Also, this PR fixes the backpropagation part in `gradient_with_order.cc`.