### PR TITLE
Specialize GeItem from shape variable

### DIFF
--- a/runtime/chxvm.proto.tmpl
+++ b/runtime/chxvm.proto.tmpl
@@ -16,6 +16,7 @@ message XCValueProto {
         LONGS = 10;
         DOUBLES = 11;
         INT_VALUES = 12;
+        SHAPE = 13;
     }
 
     required Type type = 1;
@@ -28,6 +29,7 @@ message XCValueProto {
     optional int32 sequence = 8;
     repeated double doubles = 10;
     optional int32 opaque = 11;
+    optional int32 shape = 12;
 }
 
 message XCTypeProto {

--- a/runtime/chxvm_defs.py
+++ b/runtime/chxvm_defs.py
@@ -216,7 +216,7 @@ XC_OPS = [
     ('Elu', [Array('x'), Float('alpha')], ['y']),
     ('Floor', [Array('x')], ['y']),
     ('Ceil', [Array('x')], ['y']),
-    ('Shape', [Array('data')], ['shape']),
+    ('Shape', [Array('data')], ['shape'], False),
     ('Size', [Array('data')], ['size']),
     ('Reshape', [Array('data'), Array('shape')], ['reshaped']),
     ('Expand', [Array('input'), Array('shape')], ['output']),

--- a/runtime/chxvm_defs.py
+++ b/runtime/chxvm_defs.py
@@ -89,6 +89,8 @@ class ValueInfo(_ValueInfo):
             return 'array_list'
         elif self.typ == OPAQUE:
             return 'opaque'
+        elif self.typ == SHAPE:
+            return 'shape'
         else:
             raise RuntimeError('Unknown type: %s' % self.typ)
 
@@ -224,7 +226,7 @@ XC_OPS = [
     ('Ceil', [Array('x')], ['y']),
     ('Shape', [Array('data')], [Shape('shape')]),
     ('Size', [Array('data')], ['size']),
-    ('Reshape', [Array('data'), Array('shape')], ['reshaped']),
+    ('Reshape', [Array('data'), Shape('shape')], ['reshaped']),
     ('Expand', [Array('input'), Array('shape')], ['output']),
     ('Squeeze', [Array('data'), Ints('axes')], ['squeezed']),
     ('Unsqueeze', [Array('data'), Ints('axes')], ['expanded']),

--- a/runtime/chxvm_defs.py
+++ b/runtime/chxvm_defs.py
@@ -12,6 +12,7 @@ INTS = 'INTS'
 INT_VALUES = 'INT_VALUES'
 STRING = 'STRING'
 DOUBLES = 'DOUBLES'
+SHAPE = 'SHAPE'
 
 ARG_TYPES = [
     ARRAY, OPTIONAL_ARRAY, ARRAY_LIST, SEQUENCE, OPAQUE
@@ -34,7 +35,7 @@ class ValueInfo(_ValueInfo):
         return self.typ in [INTS, INT_VALUES, ARRAY_LIST, DOUBLES]
 
     def c_type(self):
-        if self.typ in [ARRAY, OPTIONAL_ARRAY, INT, SEQUENCE, OPAQUE]:
+        if self.typ in [ARRAY, OPTIONAL_ARRAY, INT, SEQUENCE, OPAQUE, SHAPE]:
             return 'int'
         elif self.typ == FLOAT:
             return 'float'
@@ -46,6 +47,8 @@ class ValueInfo(_ValueInfo):
             return 'std::vector<int64_t>'
         elif self.typ == DOUBLES:
             return 'std::vector<double>'
+        else:
+            raise RuntimeError('Unknown type: %s', self.typ)
 
     def c_storage_type(self):
         if self.typ == INTS:
@@ -60,7 +63,7 @@ class ValueInfo(_ValueInfo):
         return ctyp
 
     def c_codegen_type(self):
-        if self.typ in (ARRAY, OPTIONAL_ARRAY, SEQUENCE, OPAQUE):
+        if self.typ in (ARRAY, OPTIONAL_ARRAY, SEQUENCE, OPAQUE, SHAPE):
             return 'ChxVMValue'
         elif self.typ == ARRAY_LIST:
             return 'std::vector<ChxVMValue>'
@@ -133,9 +136,12 @@ def String(name):
 def Doubles(name):
     return ValueInfo(DOUBLES, name)
 
+def Shape(name):
+    return ValueInfo(SHAPE, name)
+
 
 def sigil(typ):
-    if typ in [ARRAY, OPTIONAL_ARRAY]:
+    if typ in [ARRAY, OPTIONAL_ARRAY, SHAPE]:
         return '$'
     elif typ == SEQUENCE:
         return '@'
@@ -216,7 +222,7 @@ XC_OPS = [
     ('Elu', [Array('x'), Float('alpha')], ['y']),
     ('Floor', [Array('x')], ['y']),
     ('Ceil', [Array('x')], ['y']),
-    ('Shape', [Array('data')], ['shape'], False),
+    ('Shape', [Array('data')], [Shape('shape')]),
     ('Size', [Array('data')], ['size']),
     ('Reshape', [Array('data'), Array('shape')], ['reshaped']),
     ('Expand', [Array('input'), Array('shape')], ['output']),

--- a/runtime/chxvm_state.cc
+++ b/runtime/chxvm_state.cc
@@ -86,6 +86,13 @@ void ChxVMState::SetVar(int index, const ChxVMVar& var) {
     variables_[index].reset(new ChxVMVar(var));
 }
 
+void ChxVMState::SetShape(int index, chainerx::Shape s) {
+    CHECK_LE(0, index) << index;
+    CHECK_GT(variables_.size(), index) << index;
+    CHECK(!variables_[index].get());
+    variables_[index].reset(new ChxVMVar(s));
+}
+
 std::string ChxVMState::GetVarString(int index) {
     if (index < 0) return "null";
     CHECK_GT(variables_.size(), index) << index;

--- a/runtime/chxvm_state.cc
+++ b/runtime/chxvm_state.cc
@@ -86,6 +86,13 @@ void ChxVMState::SetVar(int index, const ChxVMVar& var) {
     variables_[index].reset(new ChxVMVar(var));
 }
 
+const chainerx::Shape& ChxVMState::GetShape(int index) {
+    CHECK_LE(0, index) << index;
+    CHECK_GT(variables_.size(), index) << index;
+    CHECK(variables_[index].get());
+    return variables_[index]->GetShape();
+}
+
 void ChxVMState::SetShape(int index, chainerx::Shape s) {
     CHECK_LE(0, index) << index;
     CHECK_GT(variables_.size(), index) << index;

--- a/runtime/chxvm_state.h
+++ b/runtime/chxvm_state.h
@@ -47,6 +47,7 @@ public:
     ChxVMVar* GetVar(int index);
     void SetVar(int index, const ChxVMVar& var);
 
+    const chainerx::Shape& GetShape(int index);
     void SetShape(int index, chainerx::Shape s);
 
     std::string GetVarString(int index);

--- a/runtime/chxvm_state.h
+++ b/runtime/chxvm_state.h
@@ -47,6 +47,8 @@ public:
     ChxVMVar* GetVar(int index);
     void SetVar(int index, const ChxVMVar& var);
 
+    void SetShape(int index, chainerx::Shape s);
+
     std::string GetVarString(int index);
     std::string GetVarListString(const std::vector<int>& indices);
 

--- a/runtime/chxvm_var.cc
+++ b/runtime/chxvm_var.cc
@@ -1,4 +1,5 @@
 #include "runtime/chxvm_var.h"
+#include "runtime/chainerx_util.h"
 
 #include <common/log.h>
 #include <common/strutil.h>
@@ -32,7 +33,17 @@ ChxVMVar::ChxVMVar(chainerx::Array array) : kind_(Kind::kArray), val_(array) {
 ChxVMVar::ChxVMVar(ChxVMOpaque* opaque) : kind_(Kind::kOpaque), val_(std::shared_ptr<ChxVMOpaque>(opaque)) {
 }
 
+ChxVMVar::ChxVMVar(chainerx::Scalar v) : kind_(Kind::kScalar), val_(v) {
+}
+
+ChxVMVar::ChxVMVar(chainerx::Shape v) : kind_(Kind::kShape), val_(v) {
+}
+
 const chainerx::Array& ChxVMVar::GetArray() const {
+    if (kind_ == Kind::kShape) {
+        kind_ = Kind::kArray;
+        val_ = runtime::ShapeToArray(absl::get<chainerx::Shape>(val_));
+    }
     CHECK_EQ(kind_, Kind::kArray);
     return absl::get<chainerx::Array>(val_);
 }
@@ -59,7 +70,7 @@ int64_t ChxVMVar::GetNBytes() const {
     int64_t size = 0;
     switch (kind_) {
         case Kind::kArray:
-            size = GetArray().GetNBytes();
+            size = absl::get<chainerx::Array>(val_).GetNBytes();
             break;
         case Kind::kSequence:
             for (const ChxVMVar& v : *GetSequence()) size += v.GetArray().GetNBytes();
@@ -117,14 +128,18 @@ char ChxVMVar::Sigil() const {
 std::string ChxVMVar::ToString() const {
     switch (kind_) {
         case Kind::kArray:
-            return GetArray().shape().ToString();
+            return absl::get<chainerx::Array>(val_).shape().ToString();
         case Kind::kSequence:
             return StrCat('[', JoinString(MapToString(*GetSequence(), [this](const ChxVMVar& v) { return v.ToString(); })), ']');
         case Kind::kOpaque:
             return GetOpaque()->ToString();
         case Kind::kNull:
             return "(null)";
-        case Kind::kShape:
+        case Kind::kShape: {
+            std::ostringstream oss;
+            oss << "(" << absl::get<chainerx::Shape>(val_).size() << ")";
+            return oss.str();
+        }
         case Kind::kScalar:
             break;
     }
@@ -134,7 +149,7 @@ std::string ChxVMVar::ToString() const {
 std::string ChxVMVar::DebugString() const {
     switch (kind_) {
         case Kind::kArray:
-            return GetArray().ToString();
+            return absl::get<chainerx::Array>(val_).ToString();
         case Kind::kSequence:
             return StrCat('[', JoinString(MapToString(*GetSequence(), [this](const ChxVMVar& v) { return v.DebugString(); })), ']');
         case Kind::kOpaque:
@@ -142,6 +157,7 @@ std::string ChxVMVar::DebugString() const {
         case Kind::kNull:
             return "(null)";
         case Kind::kShape:
+            return absl::get<chainerx::Shape>(val_).ToString();
         case Kind::kScalar:
             break;
     }

--- a/runtime/chxvm_var.cc
+++ b/runtime/chxvm_var.cc
@@ -1,5 +1,5 @@
-#include "runtime/chxvm_var.h"
 #include "runtime/chainerx_util.h"
+#include "runtime/chxvm_var.h"
 
 #include <common/log.h>
 #include <common/strutil.h>
@@ -33,10 +33,10 @@ ChxVMVar::ChxVMVar(chainerx::Array array) : kind_(Kind::kArray), val_(array) {
 ChxVMVar::ChxVMVar(ChxVMOpaque* opaque) : kind_(Kind::kOpaque), val_(std::shared_ptr<ChxVMOpaque>(opaque)) {
 }
 
-ChxVMVar::ChxVMVar(chainerx::Scalar v) : kind_(Kind::kScalar), val_(v) {
+ChxVMVar::ChxVMVar(chainerx::Scalar scalar) : kind_(Kind::kScalar), val_(scalar) {
 }
 
-ChxVMVar::ChxVMVar(chainerx::Shape v) : kind_(Kind::kShape), val_(v) {
+ChxVMVar::ChxVMVar(chainerx::Shape shape) : kind_(Kind::kShape), val_(shape) {
 }
 
 const chainerx::Array& ChxVMVar::GetArray() const {

--- a/runtime/chxvm_var.cc
+++ b/runtime/chxvm_var.cc
@@ -59,10 +59,16 @@ ChxVMOpaque* ChxVMVar::GetOpaque() const {
 }
 
 const chainerx::Scalar& ChxVMVar::GetScalar() const {
+    CHECK_EQ(kind_, Kind::kScalar);
     return absl::get<chainerx::Scalar>(val_);
 }
 
 const chainerx::Shape& ChxVMVar::GetShape() const {
+    if (kind_ == Kind::kArray) {
+        kind_ = Kind::kShape;
+        val_ = runtime::ArrayToShape(absl::get<chainerx::Array>(val_));
+    }
+    CHECK_EQ(kind_, Kind::kShape);
     return absl::get<chainerx::Shape>(val_);
 }
 

--- a/runtime/chxvm_var.cc
+++ b/runtime/chxvm_var.cc
@@ -1,5 +1,5 @@
-#include "runtime/chainerx_util.h"
 #include "runtime/chxvm_var.h"
+#include "runtime/chainerx_util.h"
 
 #include <common/log.h>
 #include <common/strutil.h>

--- a/runtime/chxvm_var.h
+++ b/runtime/chxvm_var.h
@@ -49,8 +49,8 @@ public:
     explicit ChxVMVar(chainerx::Array array);
     // Takes the ownership of `opaque`.
     explicit ChxVMVar(ChxVMOpaque* opaque);
-    explicit ChxVMVar(chainerx::Shape opaque);
-    explicit ChxVMVar(chainerx::Scalar opaque);
+    explicit ChxVMVar(chainerx::Shape shape);
+    explicit ChxVMVar(chainerx::Scalar scalar);
     explicit ChxVMVar(const ChxVMVar&) = default;
 
     const chainerx::Array& GetArray() const;

--- a/runtime/chxvm_var.h
+++ b/runtime/chxvm_var.h
@@ -49,6 +49,8 @@ public:
     explicit ChxVMVar(chainerx::Array array);
     // Takes the ownership of `opaque`.
     explicit ChxVMVar(ChxVMOpaque* opaque);
+    explicit ChxVMVar(chainerx::Shape opaque);
+    explicit ChxVMVar(chainerx::Scalar opaque);
     explicit ChxVMVar(const ChxVMVar&) = default;
 
     const chainerx::Array& GetArray() const;
@@ -74,10 +76,10 @@ public:
     std::string DebugString() const;
 
 private:
-    Kind kind_;
+    mutable Kind kind_;
     using VarInternalType =
             absl::variant<chainerx::Array, std::shared_ptr<ChxVMSequence>, std::shared_ptr<ChxVMOpaque>, chainerx::Scalar, chainerx::Shape>;
-    VarInternalType val_;
+    mutable VarInternalType val_;
 };
 
 std::vector<chainerx::Array> NonOptional(const ChxVMSequence& seq);

--- a/runtime/gen_chxvm.py
+++ b/runtime/gen_chxvm.py
@@ -73,6 +73,8 @@ def gen_gen_chxvm_ops_h():
                     args.append('const ChxVMSequence& %s' % name)
                 elif typ == OPAQUE:
                     args.append('const ChxVMOpaque& %s' % name)
+                elif typ == SHAPE:
+                    args.append('const chainerx::Shape& %s' % name)
                 else:
                     assert typ in FIELD_TYPES, 'Unknown type: %s' % typ
 
@@ -199,7 +201,7 @@ def gen_gen_chxvm_ops_cc():
         for i, (typ, name) in enumerate(op.inputs):
             if i:
                 line += ' << ", "'
-            if typ in [ARRAY, OPTIONAL_ARRAY, SEQUENCE, OPAQUE]:
+            if typ in [ARRAY, OPTIONAL_ARRAY, SEQUENCE, OPAQUE, SHAPE]:
                 line += ' << %s' % colored_name(typ, name)
             elif typ in (INT, FLOAT):
                 line += ' << %s' % name
@@ -257,6 +259,8 @@ def gen_gen_chxvm_ops_cc():
                     args.append('*st->GetSequence(%s)' % name)
                 elif typ == OPAQUE:
                     args.append('st->GetOpaque(%s)' % name)
+                elif typ == SHAPE:
+                    args.append('st->GetShape(%s)' % name)
 
             outputs = []
             for output in op.outputs:

--- a/runtime/gen_chxvm.py
+++ b/runtime/gen_chxvm.py
@@ -84,6 +84,8 @@ def gen_gen_chxvm_ops_h():
                     args.append('ChxVMSequence* %s' % name)
                 elif typ == OPAQUE:
                     output_ctypes.append('ChxVMOpaque*')
+                elif typ == SHAPE:
+                    output_ctypes.append('chainerx::Shape')
                 else:
                     output_ctypes.append('chainerx::Array')
 
@@ -271,6 +273,8 @@ def gen_gen_chxvm_ops_cc():
                     lines.append('st->SetArrayList(%s, %s);' % (name, call))
                 elif typ == OPAQUE:
                     lines.append('st->SetOpaque(%s, %s);' % (name, call))
+                elif typ == SHAPE:
+                    lines.append('st->SetShape(%s, %s);' % (name, call))
                 else:
                     lines.append('st->SetArray(%s, %s);' % (name, call))
             elif outputs:
@@ -290,7 +294,7 @@ def gen_gen_chxvm_ops_cc():
 
         line = 'if (st->trace_level()) std::cerr'
         for typ, name in op.outputs:
-            if typ in [ARRAY, OPTIONAL_ARRAY, SEQUENCE, OPAQUE]:
+            if typ in [ARRAY, OPTIONAL_ARRAY, SEQUENCE, OPAQUE, SHAPE]:
                 line += ' << " " << %s << "="' % colored_name(typ, name)
                 line += ' << st->GetVarString(%s)' % name
             elif typ == ARRAY_LIST:

--- a/runtime/ops/generic.cc
+++ b/runtime/ops/generic.cc
@@ -79,6 +79,13 @@ void GenericGetItemOp::RunImpl(ChxVMState* st) {
     int64_t i = static_cast<int64_t>(chainerx::AsScalar(st->GetArray(index)));
     if (i < 0) i += size;
     switch (var->kind()) {
+        case ChxVMVar::Kind::kShape: {
+            CHECK_LT(i, var->GetShape().size());
+            int64_t v = var->GetShape()[i];
+            st->SetArray(output, MakeHostArray(chainerx::Dtype::kInt64, {}, &v));
+            break;
+        }
+
         case ChxVMVar::Kind::kArray:
             CHECK_LT(i, var->GetArray().shape()[0]);
             st->SetArray(output, var->GetArray().At({i}));
@@ -92,7 +99,6 @@ void GenericGetItemOp::RunImpl(ChxVMState* st) {
         }
 
         case ChxVMVar::Kind::kScalar:
-        case ChxVMVar::Kind::kShape:
         case ChxVMVar::Kind::kOpaque:
         case ChxVMVar::Kind::kNull:
             CHECK(false) << var->DebugString();

--- a/runtime/ops/manipulation.cc
+++ b/runtime/ops/manipulation.cc
@@ -17,8 +17,8 @@ chainerx::Array SizeOp::RunImpl(ChxVMState* st, const chainerx::Array& data) {
     return MakeHostArray(chainerx::Dtype::kInt64, {}, &size);
 }
 
-chainerx::Array ReshapeOp::RunImpl(ChxVMState* st, const chainerx::Array& data, const chainerx::Array& shape) {
-    chainerx::Shape s{ArrayToShape(shape)};
+chainerx::Array ReshapeOp::RunImpl(ChxVMState* st, const chainerx::Array& data, const chainerx::Shape& shape) {
+    chainerx::Shape s = shape;
     int from_total_size = data.GetTotalSize();
     int to_total_size = 1;
     int to_minus_one_index = -1;

--- a/runtime/ops/manipulation.cc
+++ b/runtime/ops/manipulation.cc
@@ -8,8 +8,8 @@
 namespace chainer_compiler {
 namespace runtime {
 
-chainerx::Array ShapeOp::RunImpl(ChxVMState* st, const chainerx::Array& data) {
-    return ShapeToArray(data.shape());
+void ShapeOp::RunImpl(ChxVMState* st) {
+    return st->SetShape(shape, st->GetArray(data).shape());
 }
 
 chainerx::Array SizeOp::RunImpl(ChxVMState* st, const chainerx::Array& data) {

--- a/runtime/ops/manipulation.cc
+++ b/runtime/ops/manipulation.cc
@@ -8,8 +8,8 @@
 namespace chainer_compiler {
 namespace runtime {
 
-void ShapeOp::RunImpl(ChxVMState* st) {
-    return st->SetShape(shape, st->GetArray(data).shape());
+chainerx::Shape ShapeOp::RunImpl(ChxVMState* st, const chainerx::Array& data) {
+    return data.shape();
 }
 
 chainerx::Array SizeOp::RunImpl(ChxVMState* st, const chainerx::Array& data) {


### PR DESCRIPTION
relates to: #289

When `kShape` tagged `ChxVMVar` is referenced as `chainerx::Array` it converts `chainerx::Shape` internally.
Though I'm not sure whether some member variable needs to be qualified `mutable`.

Only supports `GenericGetItem` op in this PR.