### PR TITLE
Bump up Chainer version

### DIFF
--- a/compiler/merge_test.cc
+++ b/compiler/merge_test.cc
@@ -107,14 +107,6 @@ TEST(MergeTest, TransposeGemmA) {
     graph.CheckSanity("merged");
 }
 
-}  // namespace
-}  // namespace chainer_compiler
-
-// TODO(take-cheeze): EXPECT_ARRAY_* macros need to be used inside chainerx namespace.
-// These can move above when https://github.com/chainer/chainer/pull/7434 is merged.
-namespace chainerx {
-namespace {
-
 TEST(MergeTest, ConvBN) {
     using namespace chainer_compiler;
 
@@ -162,4 +154,4 @@ TEST(MergeTest, ConvBN) {
 }
 
 }  // namespace
-}  // namespace chainerx
+}  // namespace chainer_compiler

--- a/runtime/chxvm_test.cc
+++ b/runtime/chxvm_test.cc
@@ -6,6 +6,7 @@
 #include <chainerx/numeric.h>
 #include <chainerx/routines/creation.h>
 #include <chainerx/testing/array.h>
+#include <chainerx/testing/array_check.h>
 #include <chainerx/testing/context_session.h>
 
 #include <compiler/chxvm/chxvm_value.h>
@@ -36,8 +37,7 @@ TEST(ChxVMTest, Run) {
     InOuts outputs = chxvm.Run(inputs, ChxVMOptions());
     ASSERT_EQ(1, outputs.count("out"));
     chainerx::Array e = chainerx::testing::BuildArray({2, 2}).WithData<float>({2, 1, 1, 2});
-    // TODO(hamaji): Use EXPECT_ARRAY_EQ after fixing namespace?
-    EXPECT_TRUE(chainerx::AllClose(e, outputs["out"]->GetArray(), 0, 0));
+    EXPECT_ARRAY_EQ(e, outputs["out"]->GetArray());
 }
 
 }  // namespace

--- a/runtime/ops/math.cc
+++ b/runtime/ops/math.cc
@@ -1,3 +1,4 @@
+#include <chainerx/routines/arithmetic.h>
 #include <chainerx/routines/connection.h>
 #include <chainerx/routines/creation.h>
 #include <chainerx/routines/explog.h>

--- a/runtime/ops/normalization.cc
+++ b/runtime/ops/normalization.cc
@@ -1,4 +1,5 @@
 #include <chainerx/kernels/normalization.h>
+#include <chainerx/routines/arithmetic.h>
 #include <chainerx/routines/manipulation.h>
 #include <chainerx/routines/math.h>
 #include <chainerx/routines/normalization.h>

--- a/scripts/bump_submodule.sh
+++ b/scripts/bump_submodule.sh
@@ -33,7 +33,7 @@ git branch -D bump-${name} || echo 'Branch delete error ignored'
 git checkout -b bump-${name}
 
 pushd "${submodule}"
-git fetch
+git fetch origin
 git checkout origin/master
 commit=$(git log | head -1 | awk '{print $2}')
 popd


### PR DESCRIPTION
Fixes to follow chainer:
- [x] Fix header inclusion
- [x] git fetch origin explicitly
- [x] Use `EXPECT_ARRAY_EQ`