### PR TITLE
Ignore egg-info directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 .pytest_cache/
 /TAGS
 /tags
+chainer_compiler.egg-info/
 \#*\#
 __pycache__
 build/


### PR DESCRIPTION
`pip install` makes egg-info dir