### PR TITLE
Support break

### DIFF
--- a/chainer_compiler/elichika/onnx_converters.py
+++ b/chainer_compiler/elichika/onnx_converters.py
@@ -478,12 +478,13 @@ def convert_node_multiary_op(onnx_graph, node: 'nodes.NodeMultiaryOp'):
 
     if node.multiaryop == nodes.MultiaryOpType.And:
         op = 'And'
+        temp_prev = ONNXValue(onnx_graph, np.array(True, dtype=np.bool), [node, '/True'], is_constant=True)
     elif node.multiaryop == nodes.MultiaryOpType.Or:
         op = 'Or'
+        temp_prev = ONNXValue(onnx_graph, np.array(False, dtype=np.bool), [node, '/False'], is_constant=True)
     else:
         assert(False)
 
-    temp_prev = ONNXValue(onnx_graph, np.array(True, dtype=np.bool), [node, '/True'], is_constant=True)
     for idx, value_ in enumerate(node.values_list):
         temp = ONNXValue(onnx_graph, np.array(True).dtype, [node, '/temp%d' % idx])
         onnx_graph.add_node(

--- a/chainer_compiler/elichika/onnx_converters.py
+++ b/chainer_compiler/elichika/onnx_converters.py
@@ -485,7 +485,7 @@ def convert_node_multiary_op(onnx_graph, node: 'nodes.NodeMultiaryOp'):
 
     temp_prev = ONNXValue(onnx_graph, np.array(True, dtype=np.bool), [node, '/True'], is_constant=True)
     for idx, value_ in enumerate(node.values_list):
-        temp = ONNXValue(onnx_graph, np.array(True, dtype=np.bool), [node, '/temp%d' % idx])
+        temp = ONNXValue(onnx_graph, np.array(True).dtype, [node, '/temp%d' % idx])
         onnx_graph.add_node(
             op,
             [temp_prev.name, value2onnx_parameter[value_].onnx_name],
@@ -666,7 +666,7 @@ class ONNXValue:
                 self.tensor = onnx_graph.new_tensor_with_np(
                     self.np_value, self.name)
 
-        elif(any_value == np.float32 or any_value == np.float64 or any_value == np.int32 or any_value == np.int64):
+        elif(any_value == np.float32 or any_value == np.float64 or any_value == np.int32 or any_value == np.int64 or any_value == np.bool):
             self.name = generate_name()
             self.tensor = self.onnx_graph.new_empty_tensor(
                 ['TODO'], any_value, self.name)

--- a/chainer_compiler/elichika/onnx_converters.py
+++ b/chainer_compiler/elichika/onnx_converters.py
@@ -1206,10 +1206,18 @@ class ONNXGenerator:
                 body_graph = self.generate_graph(
                     node_.body_graph.input_values, node_.body_graph.output_values, node_.body_graph, onnx_graph)
 
+                t = onnx_graph.new_empty_tensor_with_value(node_.exit_cond)
+                tensor = numpy_helper.from_array(np.array(True, dtype=np.bool),
+                    name=value2onnx_parameter[node_.exit_cond].onnx_name)
+
+                onnx_node = oh.make_node(
+                    'Constant', [], [t.name], value=tensor)
+                onnx_graph.nodes.append(onnx_node)
+
                 # for
                 onnx_node = onnx_graph.add_node(
                     'Loop',
-                    [v_len] + [""] + [value2onnx_parameter[node_.iter_value].onnx_name] +
+                    [v_len, value2onnx_parameter[node_.exit_cond].onnx_name, value2onnx_parameter[node_.iter_value].onnx_name] +
                     [value2onnx_parameter[x].onnx_name for x in node.input_values],
                     [value2onnx_parameter[x].onnx_name for x in node.outputs],
                     str(node.lineprop),

--- a/chainer_compiler/elichika/parser/canonicalizer.py
+++ b/chainer_compiler/elichika/parser/canonicalizer.py
@@ -9,8 +9,16 @@ import gast
 
 class Canonicalizer(gast.NodeTransformer):
 
-    def __init__(self):
+    def __init__(self, use_illegal_identifier=True):
         super().__init__()
+        if use_illegal_identifier:
+            self.keepgoing_flag = '#keepgoing'
+            self.breaked_flag = '#breaked_'
+            self.continued_flag = '#continued_'
+        else:
+            self.keepgoing_flag = 'keepgoing'
+            self.breaked_flag = 'breaked_'
+            self.continued_flag = 'continued_'
         self.for_continue_stack = []
         self.for_breaked_stack = []
         self.flagid = -1
@@ -44,11 +52,11 @@ class Canonicalizer(gast.NodeTransformer):
             elif len(bool_values) > 1:
                 cond = gast.BoolOp(op=gast.Or(), values=bool_values)
             if isinstance(modified_node, gast.For):
-                modified_node.body.append(gast.Assign(targets=[gast.Name(id='keepgoing', ctx=gast.Store(), annotation=None)], value=gast.UnaryOp(op=gast.Not(), operand=cond)))
+                modified_node.body.append(gast.Assign(targets=[gast.Name(id=self.keepgoing_flag, ctx=gast.Store(), annotation=None)], value=gast.UnaryOp(op=gast.Not(), operand=cond)))
                 modified_node.body.append(gast.If(test=cond, body=[gast.Break()], orelse=[]))
             elif isinstance(modified_node, gast.If):
                 if isinstance(modified_node.body[0], gast.For):
-                    modified_node.body[0].body.append(gast.Assign(targets=[gast.Name(id='keepgoing', ctx=gast.Store(), annotation=None)], value=gast.UnaryOp(op=gast.Not(), operand=cond)))
+                    modified_node.body[0].body.append(gast.Assign(targets=[gast.Name(id=self.keepgoing_flag, ctx=gast.Store(), annotation=None)], value=gast.UnaryOp(op=gast.Not(), operand=cond)))
                     modified_node.body[0].body.append(gast.If(test=cond, body=[gast.Break()], orelse=[]))
         return modified_node
 
@@ -83,7 +91,7 @@ class Canonicalizer(gast.NodeTransformer):
 
     def visit_Continue(self, node):
         node = self.generic_visit(node)
-        flag = 'continued_' + str(self.getflag())
+        flag = self.continued_flag + str(self.getflag())
         self.for_continue_stack[-1].append(flag)
         replacement = gast.Assign(targets=[gast.Name(id=flag, ctx=gast.Store(), annotation=None)], value=gast.NameConstant(value=True))
         return gast.copy_location(replacement, node)
@@ -91,7 +99,7 @@ class Canonicalizer(gast.NodeTransformer):
 
     def visit_Break(self, node):
         node = self.generic_visit(node)
-        flag = 'breaked_' + str(self.getflag())
+        flag = self.breaked_flag + str(self.getflag())
         self.for_breaked_stack[-1].append(flag)
         replacement = gast.Assign(targets=[gast.Name(id=flag, ctx=gast.Store(), annotation=None)], value=gast.NameConstant(value=True))
         return gast.copy_location(replacement, node)

--- a/chainer_compiler/elichika/parser/canonicalizer.py
+++ b/chainer_compiler/elichika/parser/canonicalizer.py
@@ -44,9 +44,11 @@ class Canonicalizer(gast.NodeTransformer):
             elif len(bool_values) > 1:
                 cond = gast.BoolOp(op=gast.Or(), values=bool_values)
             if isinstance(modified_node, gast.For):
+                modified_node.body.append(gast.Assign(targets=[gast.Name(id='keepgoing', ctx=gast.Store(), annotation=None)], value=gast.UnaryOp(op=gast.Not(), operand=cond)))
                 modified_node.body.append(gast.If(test=cond, body=[gast.Break()], orelse=[]))
             elif isinstance(modified_node, gast.If):
                 if isinstance(modified_node.body[0], gast.For):
+                    modified_node.body[0].body.append(gast.Assign(targets=[gast.Name(id='keepgoing', ctx=gast.Store(), annotation=None)], value=gast.UnaryOp(op=gast.Not(), operand=cond)))
                     modified_node.body[0].body.append(gast.If(test=cond, body=[gast.Break()], orelse=[]))
         return modified_node
 

--- a/chainer_compiler/elichika/parser/nodes.py
+++ b/chainer_compiler/elichika/parser/nodes.py
@@ -26,6 +26,10 @@ class UnaryOpType(Enum):
     Not = 2,
     Unknown = 255,
 
+class MultiaryOpType(Enum):
+    And = 0,
+    Or = 1,
+    Unknown = 255,
 
 class CompareType(Enum):
     Eq = 0,
@@ -208,6 +212,16 @@ class NodeUnaryOp(Node):
     def __str__(self):
         return 'UnaryOp({},{})'.format(self.lineprop, self.unaryop)
 
+class NodeMultiaryOp(Node):
+    def __init__(self, values_list: 'values.Value', multiaryop: 'MultiaryOpType', line=-1):
+        super().__init__(line)
+        self.values_list = values_list
+        self.multiaryop = multiaryop
+
+        self.extend_inputs(values_list)
+
+    def __str__(self):
+        return 'MultiaryOp({},{})'.format(self.lineprop, self.multiaryop)
 
 class NodeCompare(Node):
     def __init__(self, left: 'values.Value', right: 'values.Value', compare: 'CompareType', line=-1):

--- a/chainer_compiler/elichika/parser/nodes.py
+++ b/chainer_compiler/elichika/parser/nodes.py
@@ -304,9 +304,10 @@ class NodeIf(Node):
 
 
 class NodeFor(Node):
-    def __init__(self, iter_value, input_values, body_graph, line=-1):
+    def __init__(self, iter_value, input_values, body_graph, exit_cond, line=-1):
         super().__init__(line)
         self.iter_value = iter_value
+        self.exit_cond = exit_cond
         self.input_values = input_values
         self.append_inputs(iter_value)
         self.extend_inputs(self.input_values)

--- a/chainer_compiler/elichika/parser/veval_multiary.py
+++ b/chainer_compiler/elichika/parser/veval_multiary.py
@@ -1,0 +1,21 @@
+from chainer_compiler.elichika.parser import nodes
+from chainer_compiler.elichika.parser import values
+from chainer_compiler.elichika.parser import functions
+
+
+def veval(op: 'nodes.MultiaryOpType', values_list: 'values.Value'):
+    if all([isinstance(value_, values.BoolValue) for value_ in values_list]):
+        if op == nodes.MultiaryOpType.And:
+            bool_value = True
+            for value_ in values_list:
+                bool_value = bool_value and value_.internal_value
+            return values.BoolValue(bool_value)
+        elif op == nodes.MultiaryOpType.Or:
+            bool_value = False
+            for value_ in values_list:
+                bool_value = bool_value or value_.internal_value
+            return values.BoolValue(bool_value)
+
+        return values.BoolValue(None)
+
+    return values.Value()

--- a/chainer_compiler/elichika/parser/vevaluator.py
+++ b/chainer_compiler/elichika/parser/vevaluator.py
@@ -1049,8 +1049,11 @@ def veval_ast_for(astc : 'AstContext', local_field : 'values.Field', graph : 'Gr
     value_outputs = values.get_outputs()
 
     break_attribute = local_field.get_attribute('keepgoing')
-    break_attribute_ref = break_attribute.get_ref()
-    break_attribute_value = break_attribute_ref.get_value()
+    if break_attribute.has_obj():
+        break_attribute_ref = break_attribute.get_ref()
+        break_attribute_value = break_attribute_ref.get_value()
+    else:
+        break_attribute_value = body_cond_value 
 
     values.pop_history()
 

--- a/chainer_compiler/elichika/parser/vevaluator.py
+++ b/chainer_compiler/elichika/parser/vevaluator.py
@@ -1048,7 +1048,7 @@ def veval_ast_for(astc : 'AstContext', local_field : 'values.Field', graph : 'Gr
     value_inputs = values.get_inputs()
     value_outputs = values.get_outputs()
 
-    break_attribute = local_field.get_attribute('keepgoing')
+    break_attribute = local_field.get_attribute('#keepgoing')
     if break_attribute.has_obj():
         break_attribute_ref = break_attribute.get_ref()
         break_attribute_value = break_attribute_ref.get_value()

--- a/testcases/elichika_tests/canonicalizer/Break_test.py
+++ b/testcases/elichika_tests/canonicalizer/Break_test.py
@@ -7,7 +7,7 @@ from chainer_compiler.elichika.testtools import compare_ast, assert_semantically
 
 class Break(unittest.TestCase):
     def setUp(self):
-        self.canonicalizer = canonicalizer.Canonicalizer()
+        self.canonicalizer = canonicalizer.Canonicalizer(use_illegal_identifier=False)
 
     def test_break(self):
         orig_code = utils.clip_head("""

--- a/testcases/elichika_tests/canonicalizer/Break_test.py
+++ b/testcases/elichika_tests/canonicalizer/Break_test.py
@@ -25,6 +25,7 @@ class Break(unittest.TestCase):
                 breaked_0 = True
             if not breaked_0:
                 x += i
+            keepgoing = not breaked_0
             if breaked_0:
                 break
         """)
@@ -60,8 +61,10 @@ class Break(unittest.TestCase):
                         breaked_1 = True
                     if not breaked_1:
                         x += i * j
+                    keepgoing = not breaked_1
                     if breaked_1:
                         break
+            keepgoing = not breaked_0
             if breaked_0:
                 break
         """)

--- a/testcases/elichika_tests/canonicalizer/Continue_test.py
+++ b/testcases/elichika_tests/canonicalizer/Continue_test.py
@@ -97,8 +97,10 @@ class Continue(unittest.TestCase):
                         breaked_2 = True
                     if not breaked_2:
                         x += i * j
+                    keepgoing = not breaked_2
                     if breaked_2:
                         break
+            keepgoing = not breaked_1
             if breaked_1:
                 break
         """)

--- a/testcases/elichika_tests/canonicalizer/Continue_test.py
+++ b/testcases/elichika_tests/canonicalizer/Continue_test.py
@@ -7,7 +7,7 @@ from chainer_compiler.elichika.testtools import compare_ast, assert_semantically
 
 class Continue(unittest.TestCase):
     def setUp(self):
-        self.canonicalizer = canonicalizer.Canonicalizer()
+        self.canonicalizer = canonicalizer.Canonicalizer(use_illegal_identifier=False)
 
     def test_continue(self):
         orig_code = utils.clip_head("""

--- a/testcases/elichika_tests/syntax/BoolOp.py
+++ b/testcases/elichika_tests/syntax/BoolOp.py
@@ -1,0 +1,44 @@
+# coding: utf-8
+
+import chainer
+import chainer.functions as F
+
+
+class BoolOp(chainer.Chain):
+    def forward(self, x, y):
+        test1 = x and y
+        test2 = x or y
+        test3 = y and x or True
+        test4 = y and x and False or True
+        ret = test1 or test2 and test3 or test4
+        return ret
+
+class BoolOpIf(chainer.Chain):
+    def forward(self, x, y):
+        ret = 0
+        if x and y:
+            ret += 1
+        if x or y:
+            ret += 2
+        if y and x or True:
+            ret += 3
+        if y and x and False or True:
+            ret += 4
+        return x or y
+
+
+# ======================================
+
+
+from chainer_compiler.elichika import testtools
+import numpy as np
+from itertools import product
+
+def main():
+    for i, (x, y) in enumerate(product([True, False], repeat=2)):
+        testtools.generate_testcase(BoolOp, [x, y], subname='boolop%d' % i)
+        testtools.generate_testcase(BoolOpIf, [x, y], subname='boolop_if%d' % i)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
- Added `keepgoing` variable during canonicalization that represents the exit-condition for break.
- Added support for `BoolOp` multiary operators And and Or (WIP).
- Currently passing 2/3 `Break.py` tests.