### PR TITLE
Start supporting `print` in elichika

### DIFF
--- a/chainer_compiler/elichika/onnx_converters.py
+++ b/chainer_compiler/elichika/onnx_converters.py
@@ -332,6 +332,14 @@ def convert_node_call(onnx_graph, node: 'nodes.NodeCall'):
             node.outputs,
             str(node.lineprop))
 
+    if isinstance(node.func, functions_builtin.PrintFunction):
+        # print
+        onnx_graph.add_node(
+            'ChainerPrint',
+            node.inputs,
+            node.outputs,
+            str(node.lineprop))
+
     if isinstance(node.func, functions_ndarray.NDArrayShapeFunction):
         # shape
         op_shape_temp = onnx_graph.new_empty_tensor(

--- a/chainer_compiler/elichika/parser/core.py
+++ b/chainer_compiler/elichika/parser/core.py
@@ -138,6 +138,9 @@ def convert_model(model: 'chainer.Chain', args=[]):
     m_list = values.FuncValue(functions_builtin.ListFunction(), None)
     values.builtin_function_converters['list'] = m_list
 
+    m_print = values.FuncValue(functions_builtin.PrintFunction(), None)
+    values.builtin_function_converters['print'] = m_print
+
     m_to_gpu = values.FuncValue(functions_builtin.CopyFunction(cuda.to_gpu), None)
     values.function_converters[cuda.to_gpu] = m_to_gpu
 

--- a/chainer_compiler/elichika/parser/functions_builtin.py
+++ b/chainer_compiler/elichika/parser/functions_builtin.py
@@ -74,6 +74,19 @@ class LenFunction(functions.FunctionBase):
         return values.ValueRef(value)
 
 
+class PrintFunction(functions.FunctionBase):
+    def __init__(self):
+        super().__init__()
+        self.name = 'print'
+        self.args.add_arg('self', None)
+        self.args.add_arg('v', None)
+
+    def vcall(self, module: 'Field', graph: 'Graph', inst: 'values.ValueRef', args: 'functions.FunctionArgInput', line=-1):
+        funcArgs = self.args.merge_inputs(inst, args)
+
+        node = nodes.NodeCall(self, funcArgs, line)
+        graph.add_node(node)
+
 class ListFunction(functions.FunctionBase):
     def __init__(self):
         super().__init__()

--- a/compiler/graph.cc
+++ b/compiler/graph.cc
@@ -226,6 +226,13 @@ std::map<Node*, int> Graph::GetNecessaryNodesAndInputCounts(const std::vector<Va
         q.push(value->producer());
     }
 
+    // Nodes without any outputs are always necessary (e.g., ChainerPrint).
+    for (Node* node : nodes_) {
+        if (node->outputs().empty()) {
+            q.push(node);
+        }
+    }
+
     // All node in this graph for sanity check.
     std::set<Node*> node_set(nodes_.begin(), nodes_.end());
 
@@ -244,13 +251,6 @@ std::map<Node*, int> Graph::GetNecessaryNodesAndInputCounts(const std::vector<Va
         for (const Value* input : node->inputs()) {
             q.push(input->producer());
             for (Node* node : input->users()) {
-                if (node->outputs().empty()) q.push(node);
-            }
-        }
-
-        // Nodes without any outputs are always necessary (e.g., ChainerPrint).
-        for (const Value* output : node->outputs()) {
-            for (Node* node : output->users()) {
                 if (node->outputs().empty()) q.push(node);
             }
         }

--- a/compiler/passes.cc
+++ b/compiler/passes.cc
@@ -29,9 +29,6 @@ namespace {
 
 void CollectGarbageNode(Graph* graph) {
     for (Node* node : graph->nodes()) {
-        if (node->op_type() == Node::kChainerPrint) {
-            continue;
-        }
         if (node->chainer_order() <= 0) graph->DetachNode(node);
     }
     graph->DeleteDetached();

--- a/compiler/passes.cc
+++ b/compiler/passes.cc
@@ -29,6 +29,9 @@ namespace {
 
 void CollectGarbageNode(Graph* graph) {
     for (Node* node : graph->nodes()) {
+        if (node->op_type() == Node::kChainerPrint) {
+            continue;
+        }
         if (node->chainer_order() <= 0) graph->DetachNode(node);
     }
     graph->DeleteDetached();

--- a/compiler/tensor.h
+++ b/compiler/tensor.h
@@ -61,8 +61,12 @@ public:
         return chx().raw_data();
     }
 
-    chainerx::Array const& chx() const {
+    const chainerx::Array& chx() const {
         return absl::get<0>(data_);
+    }
+
+    const std::vector<std::string>& str() const {
+        return absl::get<1>(data_);
     }
 
 private:

--- a/runtime/chxvm_state.cc
+++ b/runtime/chxvm_state.cc
@@ -231,6 +231,7 @@ bool HasElemInVar(chainerx::Array (*pred_fn)(const chainerx::Array&), const ChxV
                 if (HasElemInVar(pred_fn, v)) return true;
             }
             return false;
+        case ChxVMVar::Kind::kString:
         case ChxVMVar::Kind::kOpaque:
         case ChxVMVar::Kind::kNull:
             return false;

--- a/runtime/chxvm_var.cc
+++ b/runtime/chxvm_var.cc
@@ -39,6 +39,9 @@ ChxVMVar::ChxVMVar(StrictScalar scalar) : val_(scalar) {
 ChxVMVar::ChxVMVar(std::shared_ptr<ChxVMSequence> seq) : val_(seq) {
 }
 
+ChxVMVar::ChxVMVar(const std::vector<std::string>& str) : val_(str) {
+}
+
 const chainerx::Array& ChxVMVar::GetArray() const {
     switch (kind()) {
         case Kind::kShape:
@@ -90,6 +93,7 @@ int64_t ChxVMVar::GetNBytes() const {
         case Kind::kSequence:
             for (const ChxVMVar& v : *GetSequence()) size += v.GetArray().GetNBytes();
             break;
+        case Kind::kString:
         case Kind::kOpaque:
         case Kind::kNull:
             CHECK(false) << DebugString();
@@ -129,6 +133,7 @@ char ChxVMVar::Sigil() const {
         case Kind::kShape:
         case Kind::kScalar:
         case Kind::kArray:
+        case Kind::kString:
             return '$';
         case Kind::kSequence:
             return '@';

--- a/runtime/chxvm_var.cc
+++ b/runtime/chxvm_var.cc
@@ -162,6 +162,8 @@ std::string ChxVMVar::ToString() const {
         }
         case Kind::kScalar:
             return "(1)";
+        case Kind::kString:
+            return absl::get<int(Kind::kString)>(val_).front();
     }
     CHECK(false);
 }
@@ -180,6 +182,8 @@ std::string ChxVMVar::DebugString() const {
             return absl::get<chainerx::Shape>(val_).ToString();
         case Kind::kScalar:
             return static_cast<chainerx::Scalar>(absl::get<StrictScalar>(val_)).ToString();
+        case Kind::kString:
+            return absl::get<int(Kind::kString)>(val_).front();
     }
     CHECK(false);
 }

--- a/runtime/chxvm_var.h
+++ b/runtime/chxvm_var.h
@@ -44,6 +44,7 @@ public:
         kOpaque,
         kScalar,
         kShape,
+        kString,
         kNull,
     };
 
@@ -54,6 +55,7 @@ public:
     explicit ChxVMVar(std::shared_ptr<ChxVMSequence> seq);
     explicit ChxVMVar(chainerx::Shape shape);
     explicit ChxVMVar(StrictScalar scalar);
+    explicit ChxVMVar(const std::vector<std::string>& str);
     explicit ChxVMVar(const ChxVMVar&) = default;
 
     const chainerx::Array& GetArray() const;
@@ -81,8 +83,14 @@ public:
 
 private:
     struct NullType {};
-    using VarInternalType = absl::
-            variant<chainerx::Array, std::shared_ptr<ChxVMSequence>, std::shared_ptr<ChxVMOpaque>, StrictScalar, chainerx::Shape, NullType>;
+    using VarInternalType = absl::variant<
+            chainerx::Array,
+            std::shared_ptr<ChxVMSequence>,
+            std::shared_ptr<ChxVMOpaque>,
+            StrictScalar,
+            chainerx::Shape,
+            std::vector<std::string>,
+            NullType>;
     mutable VarInternalType val_;
 };
 

--- a/runtime/ops/generic.cc
+++ b/runtime/ops/generic.cc
@@ -52,6 +52,7 @@ void FreeOp::RunImpl(ChxVMState* st) {
 
 void PrintOp::RunImpl(ChxVMState* st) {
     for (int v : values) {
+        std::cerr << 'Printing!!!' << std::endl;
         std::cout << st->GetVar(v)->DebugString() << std::endl;
     }
 }

--- a/runtime/ops/generic.cc
+++ b/runtime/ops/generic.cc
@@ -52,9 +52,7 @@ void FreeOp::RunImpl(ChxVMState* st) {
 }
 
 void PrintOp::RunImpl(ChxVMState* st) {
-    std::cerr << "Printing!!!" << std::endl;
     for (int v : values) {
-        std::cerr << "Printing!!!" << std::endl;
         std::cout << st->GetVar(v)->DebugString() << std::endl;
     }
 }

--- a/runtime/ops/generic.cc
+++ b/runtime/ops/generic.cc
@@ -25,6 +25,7 @@ int64_t GetSize(ChxVMVar* var) {
             return 1;
         case ChxVMVar::Kind::kShape:
             return var->GetShape().size();
+        case ChxVMVar::Kind::kString:
         case ChxVMVar::Kind::kOpaque:
         case ChxVMVar::Kind::kNull:
             CHECK(false) << var->DebugString();
@@ -51,8 +52,9 @@ void FreeOp::RunImpl(ChxVMState* st) {
 }
 
 void PrintOp::RunImpl(ChxVMState* st) {
+    std::cerr << "Printing!!!" << std::endl;
     for (int v : values) {
-        std::cerr << 'Printing!!!' << std::endl;
+        std::cerr << "Printing!!!" << std::endl;
         std::cout << st->GetVar(v)->DebugString() << std::endl;
     }
 }
@@ -97,6 +99,7 @@ void GenericGetItemOp::RunImpl(ChxVMState* st) {
             break;
         }
 
+        case ChxVMVar::Kind::kString:
         case ChxVMVar::Kind::kOpaque:
         case ChxVMVar::Kind::kNull:
             CHECK(false) << var->DebugString();
@@ -144,6 +147,7 @@ void GenericGetSliceOp::RunImpl(ChxVMState* st) {
             break;
         }
 
+        case ChxVMVar::Kind::kString:
         case ChxVMVar::Kind::kOpaque:
         case ChxVMVar::Kind::kNull:
             CHECK(false) << var->DebugString();
@@ -232,6 +236,7 @@ void GenericAccumulateGradOp::RunImpl(ChxVMState* st) {
             break;
         }
 
+        case ChxVMVar::Kind::kString:
         case ChxVMVar::Kind::kOpaque:
         case ChxVMVar::Kind::kNull:
             CHECK(false) << var0->DebugString();

--- a/scripts/elichika_tests.py
+++ b/scripts/elichika_tests.py
@@ -94,6 +94,7 @@ TESTS = [
     Generator('syntax', 'Slice'),
     Generator('syntax', 'UserDefinedFunc'),
     Generator('syntax', 'Tuple'),
+    Generator('syntax', 'Print'),
 ]
 
 

--- a/testcases/elichika_tests/syntax/Print.py
+++ b/testcases/elichika_tests/syntax/Print.py
@@ -1,0 +1,21 @@
+# coding: utf-8
+
+import chainer
+
+class Print(chainer.Chain):
+    def forward(self, x):
+        print('test', x)
+        return 0
+
+
+# ======================================
+
+
+from chainer_compiler.elichika import testtools
+import numpy as np
+
+def main():
+    testtools.generate_testcase(Print, [10])
+
+if __name__ == '__main__':
+    main()

--- a/tools/run_onnx.cc
+++ b/tools/run_onnx.cc
@@ -228,8 +228,7 @@ ChxVMVar* StageVar(ChxVMVar* var) {
             return new ChxVMVar(seq);
         }
 
-        case ChxVMVar::Kind:
-        kString:
+        case ChxVMVar::Kind::kString:
         case ChxVMVar::Kind::kOpaque:
         case ChxVMVar::Kind::kNull:
             CHECK(false) << var->DebugString();
@@ -432,8 +431,7 @@ void VerifyOutputs(const InOuts& outputs, const TestCase& test_case, const cmdli
                     return array_str(v->GetArray());
                 case ChxVMVar::Kind::kSequence:
                     return '[' + JoinString(MapToString(NonOptional(*v->GetSequence()), array_str)) + ']';
-                case ChxVMVar::Kind:
-                kString:
+                case ChxVMVar::Kind::kString:
                 case ChxVMVar::Kind::kOpaque:
                 case ChxVMVar::Kind::kNull:
                     CHECK(false) << v->DebugString();
@@ -498,8 +496,7 @@ void VerifyOutputs(const InOuts& outputs, const TestCase& test_case, const cmdli
                 break;
             }
 
-            case ChxVMVar::Kind:
-            kString:
+            case ChxVMVar::Kind::kString:
             case ChxVMVar::Kind::kOpaque:
             case ChxVMVar::Kind::kNull:
                 CHECK(false) << expected->DebugString();

--- a/tools/run_onnx.cc
+++ b/tools/run_onnx.cc
@@ -228,6 +228,8 @@ ChxVMVar* StageVar(ChxVMVar* var) {
             return new ChxVMVar(seq);
         }
 
+        case ChxVMVar::Kind:
+        kString:
         case ChxVMVar::Kind::kOpaque:
         case ChxVMVar::Kind::kNull:
             CHECK(false) << var->DebugString();
@@ -430,6 +432,8 @@ void VerifyOutputs(const InOuts& outputs, const TestCase& test_case, const cmdli
                     return array_str(v->GetArray());
                 case ChxVMVar::Kind::kSequence:
                     return '[' + JoinString(MapToString(NonOptional(*v->GetSequence()), array_str)) + ']';
+                case ChxVMVar::Kind:
+                kString:
                 case ChxVMVar::Kind::kOpaque:
                 case ChxVMVar::Kind::kNull:
                     CHECK(false) << v->DebugString();
@@ -494,6 +498,8 @@ void VerifyOutputs(const InOuts& outputs, const TestCase& test_case, const cmdli
                 break;
             }
 
+            case ChxVMVar::Kind:
+            kString:
             case ChxVMVar::Kind::kOpaque:
             case ChxVMVar::Kind::kNull:
                 CHECK(false) << expected->DebugString();

--- a/tools/util.cc
+++ b/tools/util.cc
@@ -48,6 +48,11 @@ InOuts LoadParams(const Graph& graph) {
     for (const Value* input : graph.input_values()) {
         if (input->users().empty()) continue;
         if (const Tensor* initializer = input->initializer()) {
+            if (initializer->dtype().ToONNX() == onnx::TensorProto::STRING) {
+                CHECK(params.emplace(initializer->name(), std::shared_ptr<ChxVMVar>(new ChxVMVar(initializer->str()))).second)
+                        << "Duplicate input tensor: " << initializer->name();
+            }
+
             chainerx::Dtype dtype = ChainerXTypeFromONNX(initializer->dtype().ToONNX());
             chainerx::Shape shape(initializer->dims());
             const void* data = initializer->GetRawData();

--- a/tools/util.cc
+++ b/tools/util.cc
@@ -51,6 +51,7 @@ InOuts LoadParams(const Graph& graph) {
             if (initializer->dtype().ToONNX() == onnx::TensorProto::STRING) {
                 CHECK(params.emplace(initializer->name(), std::shared_ptr<ChxVMVar>(new ChxVMVar(initializer->str()))).second)
                         << "Duplicate input tensor: " << initializer->name();
+                continue;
             }
 
             chainerx::Dtype dtype = ChainerXTypeFromONNX(initializer->dtype().ToONNX());


### PR DESCRIPTION
- [x] Support `print` builtin function in elichika
- [x] Make nodes without outputs necessary(seems current way isn't working since those node can't be tracked from `output_values`)
- [x] Add some tests
- [x] More string support in ChxVM(though still experimental)