### PR TITLE
Introduce memory efficient export

### DIFF
--- a/chainer_compiler/__init__.py
+++ b/chainer_compiler/__init__.py
@@ -1,1 +1,2 @@
 from chainer_compiler.chainer_compiler import compile  # noqa
+from chainer_compiler.chainer_compiler import init_allocator  # noqa

--- a/chainer_compiler/chainer_compiler.py
+++ b/chainer_compiler/chainer_compiler.py
@@ -1,4 +1,5 @@
 import chainer
+import chainerx
 import os
 import sys
 import tempfile
@@ -323,3 +324,9 @@ class CompiledModel(chainer.Chain):
 
 def compile(model, inputs=None, **kwargs):
     return CompiledModel(model, inputs, **kwargs)
+
+
+def init_allocator():
+    if cupy is None:
+        return
+    chainerx._cuda.cupy_share_allocator()

--- a/chainer_compiler_cc/chainer_compiler_core.cc
+++ b/chainer_compiler_cc/chainer_compiler_core.cc
@@ -229,6 +229,7 @@ std::map<std::string, VarPtr> Run(
         bool training,
         bool check_nans,
         bool check_infs,
+        bool check_types,
         bool dump_memory_usage,
         const std::string& chrome_tracing,
         const std::map<std::string, py::function>& custom_funcs) {
@@ -238,6 +239,7 @@ std::map<std::string, VarPtr> Run(
     chxvm_opts.is_training = training;
     chxvm_opts.check_nans = check_nans;
     chxvm_opts.check_infs = check_infs;
+    chxvm_opts.check_types = check_types;
     chxvm_opts.dump_memory_usage = dump_memory_usage;
     if (!chrome_tracing.empty()) {
         chxvm_opts.chrome_tracing = new runtime::ChromeTracingEmitter();
@@ -285,6 +287,7 @@ void InitChxVM(py::module& m) {
           "training"_a = false,
           "check_nans"_a = false,
           "check_infs"_a = false,
+          "check_types"_a = false,
           "dump_memory_usage"_a = false,
           "chrome_tracing"_a = "",
           "custom_funcs"_a = py::dict());

--- a/examples/mnist/train_mnist.py
+++ b/examples/mnist/train_mnist.py
@@ -83,6 +83,7 @@ def main():
                         help='Use unified memory for large model')
     args = parser.parse_args()
 
+    chainer_compiler.init_allocator()
     device = chainer.get_device(args.device)
 
     print('Device: {}'.format(device))

--- a/runtime/chxvm.cc
+++ b/runtime/chxvm.cc
@@ -133,8 +133,10 @@ InOuts ChxVM::Run(const InOuts& program_inputs, const ChxVMOptions& options) {
             if (static_cast<int>(input->dtype) == 0) {
                 continue;
             }
-            CHECK_EQ(input->dtype, a.dtype()) << "Input '" << input->name << "' has an unexpected dtype";
-            CHECK_EQ(input->shape, a.shape()) << "Input '" << input->name << "' has an unexpected shape";
+            if (options.check_types) {
+              CHECK_EQ(input->dtype, a.dtype()) << "Input '" << input->name << "' has an unexpected dtype";
+              CHECK_EQ(input->shape, a.shape()) << "Input '" << input->name << "' has an unexpected shape";
+            }
         } else {
             CHECK_EQ(static_cast<int>(input->dtype), 0) << "Input '" << input->name << "' must be a tensor";
         }

--- a/runtime/chxvm.cc
+++ b/runtime/chxvm.cc
@@ -134,8 +134,8 @@ InOuts ChxVM::Run(const InOuts& program_inputs, const ChxVMOptions& options) {
                 continue;
             }
             if (options.check_types) {
-              CHECK_EQ(input->dtype, a.dtype()) << "Input '" << input->name << "' has an unexpected dtype";
-              CHECK_EQ(input->shape, a.shape()) << "Input '" << input->name << "' has an unexpected shape";
+                CHECK_EQ(input->dtype, a.dtype()) << "Input '" << input->name << "' has an unexpected dtype";
+                CHECK_EQ(input->shape, a.shape()) << "Input '" << input->name << "' has an unexpected shape";
             }
         } else {
             CHECK_EQ(static_cast<int>(input->dtype), 0) << "Input '" << input->name << "' must be a tensor";


### PR DESCRIPTION
This PR remove the restriction that the batch-size is consistent during the training.
By this way, we can export the model with batch-size one to reduce memory consumption.

Some concern:
* I made some `CHECK_EQ` to be checked only when options.check_type is true. Is this OK?
* Also, I introduced `init_allocator` function. But I'm not sure if this is really useful.