### PR TITLE
Support `Round` and `BitShift` operator

### DIFF
--- a/compiler/chxvm/emitter.cc
+++ b/compiler/chxvm/emitter.cc
@@ -680,6 +680,10 @@ private:
             CHECK_GE(4UL, node.inputs().size());
             CHECK_EQ(1UL, node.outputs().size());
             EMIT(ConvInteger, out(0), in(0), in(1), oin(2), oin(3), strides(), pads(), node.group());
+        } else if (node.op_type() == Node::kBitShift) {
+            CHECK_EQ(2UL, node.inputs().size());
+            CHECK_EQ(1UL, node.outputs().size());
+            EMIT(BitShift, out(0), in(0), in(1), node.direction());
         } else {
             CHECK(false) << "Unsupported op: " << node.op_type();
         }

--- a/compiler/chxvm/emitter.cc
+++ b/compiler/chxvm/emitter.cc
@@ -251,6 +251,7 @@ private:
         EMIT_SIMPLE_UNARY_OP(Node::kIsNaN, IsNaN);
         EMIT_SIMPLE_UNARY_OP(Node::kIsInf, IsInf);
         EMIT_SIMPLE_UNARY_OP(Node::kSign, Sign);
+        EMIT_SIMPLE_UNARY_OP(Node::kRound, Round);
 
         EMIT_SIMPLE_BINARY_OP(Node::kAdd, Add);
         EMIT_SIMPLE_BINARY_OP(Node::kSub, Sub);

--- a/compiler/gen_node.py
+++ b/compiler/gen_node.py
@@ -231,6 +231,7 @@ NodeDef('ConvInteger', (2, 3, 4), 1,
         kernel_shape=[int],
         pads=[int],
         strides=[int])
+NodeDef('Round', 1, 1)
 
 NodeDef('ChainerLinear', (2, 3), 1, n_batch_axes=1)
 NodeDef('ChainerLinearGradWeight', 2, 1)

--- a/compiler/gen_node.py
+++ b/compiler/gen_node.py
@@ -232,6 +232,7 @@ NodeDef('ConvInteger', (2, 3, 4), 1,
         pads=[int],
         strides=[int])
 NodeDef('Round', 1, 1)
+NodeDef('BitShift', 2, 1, direction='LEFT')
 
 NodeDef('ChainerLinear', (2, 3), 1, n_batch_axes=1)
 NodeDef('ChainerLinearGradWeight', 2, 1)

--- a/configs/chxvm.json
+++ b/configs/chxvm.json
@@ -49,6 +49,7 @@
         "Atanh": true,
         "AveragePool": true,
         "BatchNormalization": true,
+        "BitShift": true,
         "Cast": true,
         "Ceil": true,
         "ChainerAveragePoolGrad": true,

--- a/configs/chxvm.json
+++ b/configs/chxvm.json
@@ -161,6 +161,7 @@
         "Relu": true,
         "Reshape": true,
         "Resize": true,
+        "Round": true,
         "Selu": true,
         "Shape": true,
         "Sigmoid": true,

--- a/runtime/chxvm_defs.py
+++ b/runtime/chxvm_defs.py
@@ -420,6 +420,7 @@ XC_OPS = [
      [Array('x'), Array('w'),
       OptionalScalar('x_zero_point'), OptionalArray('w_zero_point'),
       Ints('strides'), Ints('pads'), Int('group')], ['y']),
+    ('Round', [Array('x')], ['y']),
 ]
 
 XC_CUSTOM_FIELD_OPS = [

--- a/runtime/chxvm_defs.py
+++ b/runtime/chxvm_defs.py
@@ -421,6 +421,7 @@ XC_OPS = [
       OptionalScalar('x_zero_point'), OptionalArray('w_zero_point'),
       Ints('strides'), Ints('pads'), Int('group')], ['y']),
     ('Round', [Array('x')], ['y']),
+    ('BitShift', [Array('x'), Array('y'), String('direction')], ['z']),
 ]
 
 XC_CUSTOM_FIELD_OPS = [

--- a/runtime/ops/quantize.cc
+++ b/runtime/ops/quantize.cc
@@ -145,5 +145,26 @@ chainerx::Array RoundOp::RunImpl(ChxVMState* st, const chainerx::Array& x) {
     return MakeArray(chainerx::Dtype::kFloat64, x.shape(), result_data.data()).AsType(x.dtype());
 }
 
+chainerx::Array BitShiftOp::RunImpl(ChxVMState* st, const chainerx::Array& x, const chainerx::Array& in_y) {
+    chainerx::Array int64_y = in_y.BroadcastTo(x.shape()).AsType(chainerx::Dtype::kInt64);
+    chainerx::Array int64_x = x.AsType(chainerx::Dtype::kInt64);
+    const int64_t* x_ptr = reinterpret_cast<const int64_t*>(int64_x.raw_data());
+    const int64_t* y_ptr = reinterpret_cast<const int64_t*>(int64_y.raw_data());
+    std::vector<int64_t> result_data(x.GetTotalSize());
+
+    if (direction == "LEFT") {
+        for (size_t i = 0; i < result_data.size(); ++i) {
+            result_data[i] = x_ptr[i] << y_ptr[i];
+        }
+    } else {
+        CHECK_EQ("RIGHT", direction);
+        for (size_t i = 0; i < result_data.size(); ++i) {
+            result_data[i] = x_ptr[i] >> y_ptr[i];
+        }
+    }
+
+    return MakeArray(chainerx::Dtype::kInt64, x.shape(), result_data.data()).AsType(x.dtype());
+}
+
 }  // namespace runtime
 }  // namespace chainer_compiler

--- a/runtime/ops/quantize.cc
+++ b/runtime/ops/quantize.cc
@@ -134,5 +134,16 @@ chainerx::Array ConvIntegerOp::RunImpl(
     return Conv(x, w, nonstd::nullopt, comp_strides, comp_pads, group).AsType(chainerx::Dtype::kInt32);
 }
 
+chainerx::Array RoundOp::RunImpl(ChxVMState* st, const chainerx::Array& x) {
+    // TODO(take-cheeze): Implement in ChainerX
+    std::vector<double> result_data(x.GetTotalSize());
+    chainerx::Array double_x = x.AsType(chainerx::Dtype::kFloat64);
+    const double* x_ptr = reinterpret_cast<const double*>(double_x.raw_data());
+    for (size_t i = 0; i < result_data.size(); ++i) {
+        result_data[i] = std::rint(x_ptr[i]);
+    }
+    return MakeArray(chainerx::Dtype::kFloat64, x.shape(), result_data.data()).AsType(x.dtype());
+}
+
 }  // namespace runtime
 }  // namespace chainer_compiler

--- a/scripts/runtests.py
+++ b/scripts/runtests.py
@@ -434,6 +434,7 @@ TEST_CASES = [
     TestCase(NODE_TEST, 'test_convinteger_with_padding'),
     TestCase(NODE_TEST, 'test_basic_convinteger'),
     TestCase(NODE_TEST, 'test_matmulinteger'),
+    TestCase(NODE_TEST, 'test_round'),
 ]
 
 TEST_CASES += [

--- a/scripts/runtests.py
+++ b/scripts/runtests.py
@@ -435,6 +435,15 @@ TEST_CASES = [
     TestCase(NODE_TEST, 'test_basic_convinteger'),
     TestCase(NODE_TEST, 'test_matmulinteger'),
     TestCase(NODE_TEST, 'test_round'),
+    TestCase(NODE_TEST, 'test_bitshift_left_uint8'),
+    TestCase(NODE_TEST, 'test_bitshift_right_uint8'),
+    # TODO(take-cheeze): Support larger unsigned int types
+    # TestCase(NODE_TEST, 'test_bitshift_left_uint64'),
+    # TestCase(NODE_TEST, 'test_bitshift_left_uint32'),
+    # TestCase(NODE_TEST, 'test_bitshift_left_uint16'),
+    # TestCase(NODE_TEST, 'test_bitshift_right_uint64'),
+    # TestCase(NODE_TEST, 'test_bitshift_right_uint32'),
+    # TestCase(NODE_TEST, 'test_bitshift_right_uint16'),
 ]
 
 TEST_CASES += [


### PR DESCRIPTION
Larger unsigned types are not supported in ChainerX so they are not testable.