### PR TITLE
Split translation part from chainer_compiler.compile

### DIFF
--- a/chainer_compiler/__init__.py
+++ b/chainer_compiler/__init__.py
@@ -1,1 +1,5 @@
 from chainer_compiler.chainer_compiler import compile  # noqa
+from chainer_compiler.chainer_compiler import compile_onnx  # noqa
+from chainer_compiler.chainer_compiler import export  # noqa
+from chainer_compiler.chainer_compiler import use_unified_memory_allocator  # noqa
+from chainer_compiler.chainer_compiler import use_chainerx_shared_allocator  # noqa

--- a/chainer_compiler/chainer_compiler.py
+++ b/chainer_compiler/chainer_compiler.py
@@ -220,7 +220,6 @@ class CompiledModel(chainer.Chain):
         self.dump_onnx = dump_onnx
         self.computation_order = computation_order
 
-        self.compiled = False
         self.param_names = None
         self.param_values = None
         # Propagate device from `model` before compiling it.
@@ -254,8 +253,6 @@ class CompiledModel(chainer.Chain):
         self.fwd = fwd_graph.compile(skip_inference=True)
         self.bwd = bwd_graph.compile(skip_inference=True)
         self.param_names = fwd_graph.param_names()
-
-        self.compiled = True
 
         if self.used_translator == 'ch2o':
             convert_rule = lambda key: key  # noqa
@@ -292,11 +289,6 @@ class CompiledModel(chainer.Chain):
                 raise NotImplementedError('Initial value is uknown: ' + name)
 
     def forward(self, *args):
-        if not self.compiled:
-            outputs = self.mc(*args)
-            self.compile(args)
-            return outputs
-
         inputs = list(args)
         flat_inputs = _flatten(inputs)
         runner = RunCompiledModel(self, inputs)

--- a/chainer_compiler/chainer_compiler.py
+++ b/chainer_compiler/chainer_compiler.py
@@ -324,4 +324,6 @@ def use_unified_memory_allocator():
 
 
 def use_chainerx_shared_allocator():
+    if cupy is None:
+        return
     chainerx._cuda.cupy_share_allocator()

--- a/examples/mnist/train_mnist.py
+++ b/examples/mnist/train_mnist.py
@@ -35,7 +35,7 @@ def fake_dataset():
         inputs = []
         labels = []
         for i in range(size):
-            inputs.append(np.random.rand(224).astype(np.float32))
+            inputs.append(np.random.rand(784).astype(np.float32))
             labels.append(np.random.randint(10))
         return inputs, labels
     train = chainer.datasets.TupleDataset(*gen(150))
@@ -106,13 +106,17 @@ def main():
         if args.use_unified_memory:
             chainer_compiler.use_unified_memory_allocator()
         mlp.to_device(device)
-        x = mlp.xp.zeros((args.batchsize, 224)).astype(np.float32)
+        x = mlp.xp.zeros((args.batchsize, 784)).astype(np.float32)
         chainer_compiler.export(mlp, [x], args.export, args.translator)
         return
 
     if args.compile is not None:
         chainer_compiler.use_chainerx_shared_allocator()
         mlp.to_device(device)
+        with chainer.using_config('enable_backprop', False),\
+                chainer.using_config('train', False):
+            x = mlp.xp.zeros((1, 784)).astype(np.float32)
+            mlp(x)  # initialize model parameters before compile
         mlp = chainer_compiler.compile_onnx(
             mlp,
             args.compile,

--- a/examples/mnist/train_mnist.py
+++ b/examples/mnist/train_mnist.py
@@ -68,14 +68,20 @@ def main():
     group.add_argument('--gpu', '-g', dest='device',
                        type=int, nargs='?', const=0,
                        help='GPU ID (negative value indicates CPU)')
-    parser.add_argument('--compile', action='store_true',
+
+    parser.add_argument('--export', type=str, default=None,
+                        help='Export the model to ONNX')
+    parser.add_argument('--compile', type=str, default=None,
                         help='Compile the model')
+
     parser.add_argument('--dump_onnx', action='store_true',
                         help='Dump ONNX model after optimization')
     parser.add_argument('--iterations', '-I', type=int, default=None,
                         help='Number of iterations to train')
     parser.add_argument('--use-fake-data', action='store_true',
                         help='Use fake data')
+    parser.add_argument('--translator', type=str, default='onnx_chainer',
+                        help='ch2o or onnx_chainer')
     parser.add_argument('--computation_order', type=str, default=None,
                         help='Computation order in backpropagation')
     parser.add_argument('--use_unified_memory', dest='use_unified_memory',
@@ -95,25 +101,25 @@ def main():
     # Classifier reports softmax cross entropy loss and accuracy at every
     # iteration, which will be used by the PrintReport extension below.
     mlp = MLP(args.unit, 10)
-    if args.compile:
-        if args.computation_order is None:
-            translator = 'ch2o'
-        else:
-            translator = 'onnx_chainer'
-        export_allocator = None
-        runtime_allocator = None
-        if args.use_unified_memory:
-            import cupy
-            # unified memory
-            export_allocator = cupy.cuda.memory.malloc_managed
-            runtime_allocator = cupy.get_default_memory_pool().malloc
 
-        mlp = chainer_compiler.compile(
-            mlp, dump_onnx=args.dump_onnx,
-            translator=translator,
-            computation_order=args.computation_order,
-            export_allocator=export_allocator,
-            runtime_allocator=runtime_allocator)
+    if args.export is not None:
+        if args.use_unified_memory:
+            chainer_compiler.use_unified_memory_allocator()
+        mlp.to_device(device)
+        x = mlp.xp.zeros((args.batchsize, 224)).astype(np.float32)
+        chainer_compiler.export(mlp, [x], args.export, args.translator)
+        return
+
+    if args.compile is not None:
+        chainer_compiler.use_chainerx_shared_allocator()
+        mlp.to_device(device)
+        mlp = chainer_compiler.compile_onnx(
+            mlp,
+            args.compile,
+            args.translator,
+            dump_onnx=args.dump_onnx,
+            computation_order=args.computation_order)
+
     model = L.Classifier(mlp)
     model.to_device(device)
     device.use()

--- a/scripts/run-travis-tests.sh
+++ b/scripts/run-travis-tests.sh
@@ -41,7 +41,7 @@ PYTHONPATH=. run pytest pytest -sv tests
 PYTHONPATH=. run canonicalizer_tests pytest testcases/elichika_tests/canonicalizer
 
 PYTHONPATH=. run train_mnist_export python3 examples/mnist/train_mnist.py \
-     -d native --export /tmp/tmp_mnist_model.onnx -I 3 --use-fake-data
+     -d -1 --export /tmp/tmp_mnist_model.onnx -I 3 --use-fake-data
 PYTHONPATH=. run train_mnist_compile python3 examples/mnist/train_mnist.py \
      -d native --compile /tmp/tmp_mnist_model.onnx -I 3 --use-fake-data
 

--- a/scripts/run-travis-tests.sh
+++ b/scripts/run-travis-tests.sh
@@ -40,8 +40,10 @@ PYTHONPATH=. run runtests ./scripts/runtests.py 2>&1
 PYTHONPATH=. run pytest pytest -sv tests
 PYTHONPATH=. run canonicalizer_tests pytest testcases/elichika_tests/canonicalizer
 
-PYTHONPATH=. run train_mnist python3 examples/mnist/train_mnist.py \
-     -d native --compile -I 3 --use-fake-data
+PYTHONPATH=. run train_mnist_export python3 examples/mnist/train_mnist.py \
+     -d native --export /tmp/tmp_mnist_model.onnx -I 3 --use-fake-data
+PYTHONPATH=. run train_mnist_compile python3 examples/mnist/train_mnist.py \
+     -d native --compile /tmp/tmp_mnist_model.onnx -I 3 --use-fake-data
 
 run tools_dump ./build/tools/dump out/ch2o_model_MLP_with_loss
 


### PR DESCRIPTION
This PR changes the interface of `CompiledModel` so that it is split into translation part and compilation part.

I also changed an MNIST example to run export part and compile part separately.