### PR TITLE
Supporting Dict & With syntax + interface for elichika builtin flags

### DIFF
--- a/chainer_compiler/elichika/onnx_converters.py
+++ b/chainer_compiler/elichika/onnx_converters.py
@@ -317,7 +317,9 @@ def convert_node_bin_op(onnx_graph, node: 'nodes.NodeBinOp'):
         seq_right = right.create_sequence()
         onnx_graph.add_node(binops[node.binop], [seq_left, seq_right], [
                             value2onnx_parameter[node.outputs[0]].onnx_name], None)
-
+    elif isinstance(node.left, values.StrValue):
+        # Constant propagation, string concatenation, etc.
+        pass
     else:
         if node.binop == nodes.BinOpType.FloorDiv:
 

--- a/chainer_compiler/elichika/parser/__init__.py
+++ b/chainer_compiler/elichika/parser/__init__.py
@@ -3,4 +3,5 @@ from chainer_compiler.elichika.parser import nodes
 from chainer_compiler.elichika.parser import values
 from chainer_compiler.elichika.parser import functions
 from chainer_compiler.elichika.parser import utils
+from chainer_compiler.elichika.parser import flags
 

--- a/chainer_compiler/elichika/parser/core.py
+++ b/chainer_compiler/elichika/parser/core.py
@@ -153,7 +153,7 @@ def convert_model(model: 'chainer.Chain', args=[]):
 
     # generate VEvalFlag functions
     def add_veval_flag_function(name:'str', func):
-        f = values.FuncValue(functions_builtin.VEvalOptionFunction(func, vevaluator.common_flags_cache), None)
+        f = values.FuncValue(functions_builtin.VEvalOptionFunction(func), None)
         values.builtin_function_converters[name] = f
 
     add_veval_flag_function('eval_as_written_target', flags.eval_as_written_target)

--- a/chainer_compiler/elichika/parser/core.py
+++ b/chainer_compiler/elichika/parser/core.py
@@ -142,6 +142,9 @@ def convert_model(model: 'chainer.Chain', args=[]):
     m_print = values.FuncValue(functions_builtin.PrintFunction(), None)
     values.builtin_function_converters['print'] = m_print
 
+    m_getattr = values.FuncValue(functions_builtin.GetAttrFunction(), None)
+    values.builtin_function_converters['getattr'] = m_getattr
+
     m_to_gpu = values.FuncValue(functions_builtin.CopyFunction(cuda.to_gpu), None)
     values.function_converters[cuda.to_gpu] = m_to_gpu
 
@@ -191,7 +194,7 @@ def convert_model(model: 'chainer.Chain', args=[]):
 
     forward_func_value = forward_func.get_value()
     ret = forward_func_value.func.vcall(
-        default_module, graph, forward_func_value.obj, finput)
+        default_module, graph, forward_func_value.obj, finput).get_ref()
     assert(ret is None or isinstance(ret, values.ValueRef))
 
     def try_get_value(value) -> 'values.Value':

--- a/chainer_compiler/elichika/parser/core.py
+++ b/chainer_compiler/elichika/parser/core.py
@@ -16,6 +16,7 @@ from chainer_compiler.elichika.parser import functions_builtin
 from chainer_compiler.elichika.parser import functions_ndarray
 from chainer_compiler.elichika.parser import utils
 from chainer_compiler.elichika.parser.graphs import Graph
+from chainer_compiler.elichika.parser import flags
 import numpy as np
 import six
 
@@ -146,6 +147,15 @@ def convert_model(model: 'chainer.Chain', args=[]):
 
     m_to_cpu = values.FuncValue(functions_builtin.CopyFunction(cuda.to_cpu), None)
     values.function_converters[cuda.to_cpu] = m_to_cpu
+
+    # generate VEvalFlag functions
+    def add_veval_flag_function(name:'str', func):
+        f = values.FuncValue(functions_builtin.VEvalOptionFunction(func, vevaluator.common_flags_cache), None)
+        values.builtin_function_converters[name] = f
+
+    add_veval_flag_function('eval_as_written_target', flags.eval_as_written_target)
+    add_veval_flag_function('ignore_branch', flags.ignore_branch)
+    add_veval_flag_function('for_unroll', flags.for_unroll)
 
     # generate default module
     default_module = values.ValueRef(values.ModuleValue(sys.modules[model.__module__]))

--- a/chainer_compiler/elichika/parser/flags.py
+++ b/chainer_compiler/elichika/parser/flags.py
@@ -7,5 +7,5 @@ def eval_as_written_target():
 def ignore_branch():
     return DummyFlag()
 
-def for_unroll():
+def for_unroll(unroll=True):
     return DummyFlag()

--- a/chainer_compiler/elichika/parser/flags.py
+++ b/chainer_compiler/elichika/parser/flags.py
@@ -1,0 +1,11 @@
+from chainer_compiler.elichika.parser.utils import DummyFlag
+
+
+def eval_as_written_target():
+    return DummyFlag()
+
+def ignore_branch():
+    return DummyFlag()
+
+def for_unroll():
+    return DummyFlag()

--- a/chainer_compiler/elichika/parser/functions.py
+++ b/chainer_compiler/elichika/parser/functions.py
@@ -311,7 +311,8 @@ class FunctionBase():
 
         self.base_func = None
 
-    def vcall(self, module: 'values.Field', graph: 'core.Graph', inst: 'values.Value', args=[], line=-1):
+    def vcall(self, module: 'values.Field', graph: 'graphs.Graph', inst: 'values.ValueRef', args: 'functions.FunctionArgInput',
+              option: 'vevaluator.VEvalOption' = None, line=-1):
         return None
 
 
@@ -344,7 +345,8 @@ class UserDefinedClassConstructorFunction(FunctionBase):
         ast_ = gast.ast_to_gast(ast.parse(code)).body[0]
         self.ast = canonicalizer.Canonicalizer().visit(ast_)
 
-    def vcall(self, module: 'values.Field', graph: 'graphs.Graph', inst: 'values.ValueRef', args: 'FunctionArgInput', line=-1):
+    def vcall(self, module: 'values.Field', graph: 'graphs.Graph', inst: 'values.ValueRef', args: 'functions.FunctionArgInput',
+              option: 'vevaluator.VEvalOption' = None, line=-1):
         ret = values.ValueRef(values.UserDefinedInstance(
             module, None, self.classinfo))
         inst = ret
@@ -383,7 +385,8 @@ class UserDefinedFunction(FunctionBase):
         ast_ = gast.ast_to_gast(ast.parse(code)).body[0]
         self.ast = canonicalizer.Canonicalizer().visit(ast_)
 
-    def vcall(self, module: 'values.Field', graph: 'core.Graph', inst: 'values.ValueRef', args: 'FunctionArgInput', line=-1):
+    def vcall(self, module: 'values.Field', graph: 'graphs.Graph', inst: 'values.ValueRef', args: 'functions.FunctionArgInput',
+              option: 'vevaluator.VEvalOption' = None, line=-1):
         func_field = values.Field()
         func_field.set_module(module)
 
@@ -391,7 +394,7 @@ class UserDefinedFunction(FunctionBase):
         funcArgs = self.args.merge_inputs(inst, args)
 
         for k, v in funcArgs.keywords.items():
-            func_field.get_field().get_attribute(k, from_module=False).revise(v)
+            func_field.get_field().get_attribute(k, from_module=False).revise(utils.try_get_ref(v, self.name, utils.LineProperty()))
 
         astc = vevaluator.AstContext(self.ast.body, self.lineno - 1, filename=self.filename)
         ret = vevaluator.veval_ast(astc, func_field, graph)

--- a/chainer_compiler/elichika/parser/functions_builtin.py
+++ b/chainer_compiler/elichika/parser/functions_builtin.py
@@ -178,7 +178,7 @@ class KeysFunction(functions.FunctionBase):
         if inst.in_container:
             raise Exception('Invalid operation')
 
-        keys = inst.get_value().internal_keys
+        keys = inst.get_value().internal_keys.values()
 
         vargs = []
         vargs_value = []
@@ -208,11 +208,11 @@ class ValuesFunction(functions.FunctionBase):
         if inst.in_container:
             raise Exception('Invalid operation')
 
-        key_refs = inst.get_value().internal_keys
+        key_hashes = inst.get_value().internal_keys.keys()
         attributes = inst.get_value().internal_values
         vargs = []
-        for key in key_refs:
-            varg = attributes.get_attribute(key.get_value().encode())
+        for hash in key_hashes:
+            varg = attributes.get_attribute(hash)
             if varg.has_obj():
                 vargs.append(varg.get_ref().get_value())
             else:

--- a/chainer_compiler/elichika/parser/functions_builtin.py
+++ b/chainer_compiler/elichika/parser/functions_builtin.py
@@ -11,22 +11,6 @@ import chainer.links as L
 def create_return_value_in_chainer_function():
     return values.TensorValue()
 
-def try_get_ref(value, name, lineprop) -> 'values.ValueRef':
-    if value is None:
-        utils.print_warning('Failed to get value in "{}".'.format(name), lineprop)
-        return None
-
-    if isinstance(value, values.Value):
-        assert(False)
-
-    if isinstance(value, values.Attribute):
-        if value.has_obj():
-            return value.get_ref()
-
-    if isinstance(value, values.ValueRef):
-        return value
-
-    return None
 
 class ChainerFunction(functions.FunctionBase):
     def __init__(self, func, ret_value_func = create_return_value_in_chainer_function):
@@ -36,7 +20,8 @@ class ChainerFunction(functions.FunctionBase):
         self.base_func = func
         self.ret_value_func = ret_value_func
 
-    def vcall(self, module: 'Field', graph: 'Graph', inst: 'values.ValueRef', args: 'functions.FunctionArgInput', line=-1):
+    def vcall(self, module: 'values.Field', graph: 'graphs.Graph', inst: 'values.ValueRef', args: 'functions.FunctionArgInput',
+              option: 'vevaluator.VEvalOption' = None, line=-1):
         funcArgs = self.args.merge_inputs(inst, args)
 
         node = nodes.NodeCall(self, funcArgs, line)
@@ -52,7 +37,8 @@ class CopyFunction(functions.FunctionBase):
         super().__init__()
         self.name = str(func)
 
-    def vcall(self, module: 'Field', graph: 'Graph', inst: 'values.ValueRef', args: 'functions.FunctionArgInput', line=-1):
+    def vcall(self, module: 'values.Field', graph: 'graphs.Graph', inst: 'values.ValueRef', args: 'functions.FunctionArgInput',
+              option: 'vevaluator.VEvalOption' = None, line=-1):
         node = nodes.NodeCopy(args.inputs[0].get_value())
         graph.add_node(node)
         ret = functions.generate_copied_value(args.inputs[0].get_value())
@@ -64,14 +50,28 @@ class RangeFunction(functions.FunctionBase):
         super().__init__()
         self.name = 'range'
 
-    def vcall(self, module: 'Field', graph: 'Graph', inst: 'values.ValueRef', args: 'functions.FunctionArgInput', line=-1):
-        node = nodes.NodeGenerate(
-            'range', [v.get_value() for v in args.inputs], line)
-        graph.add_node(node)
-        value = values.RangeValue()
-        value.name = '@F.{}.{}'.format(line, self.name)
-        node.set_outputs([value])
-        return values.ValueRef(value)
+    def vcall(self, module: 'values.Field', graph: 'graphs.Graph', inst: 'values.ValueRef', args: 'functions.FunctionArgInput',
+              option: 'vevaluator.VEvalOption' = None, line=-1):
+
+        if option._for_unroll:
+            for ref in args.inputs:
+                if not ref.get_value().has_constant_value():
+                    assert False
+
+            refs = []
+            for num in range(*(ref.get_value().internal_value for ref in args.inputs)):
+                refs.append(values.ValueRef(values.NumberValue(num)))
+
+            value = values.ListValue(refs)
+            return values.ValueRef(value)
+        else:
+            node = nodes.NodeGenerate(
+                'range', [v.get_value() for v in args.inputs], line)
+            graph.add_node(node)
+            value = values.RangeValue()
+            value.name = '@F.{}.{}'.format(line, self.name)
+            node.set_outputs([value])
+            return values.ValueRef(value)
 
 
 class LenFunction(functions.FunctionBase):
@@ -79,7 +79,8 @@ class LenFunction(functions.FunctionBase):
         super().__init__()
         self.name = 'len'
 
-    def vcall(self, module: 'Field', graph: 'Graph', inst: 'values.ValueRef', args: 'functions.FunctionArgInput', line=-1):
+    def vcall(self, module: 'values.Field', graph: 'graphs.Graph', inst: 'values.ValueRef', args: 'functions.FunctionArgInput',
+              option: 'vevaluator.VEvalOption' = None, line=-1):
         node = nodes.NodeLen(
             args.inputs[0].get_value(),  # TODO: Check this.
             line
@@ -98,7 +99,8 @@ class PrintFunction(functions.FunctionBase):
         self.args.add_arg('self', None)
         self.args.add_arg('v', None)
 
-    def vcall(self, module: 'Field', graph: 'Graph', inst: 'values.ValueRef', args: 'functions.FunctionArgInput', line=-1):
+    def vcall(self, module: 'values.Field', graph: 'graphs.Graph', inst: 'values.ValueRef', args: 'functions.FunctionArgInput',
+              option: 'vevaluator.VEvalOption' = None, line=-1):
         funcArgs = self.args.merge_inputs(inst, args)
 
         node = nodes.NodeCall(self, funcArgs, line)
@@ -110,7 +112,8 @@ class ListFunction(functions.FunctionBase):
         self.name = 'list'
         self.args.add_arg('value', values.ValueRef(values.NoneValue()))
 
-    def vcall(self, module: 'Field', graph: 'Graph', inst: 'values.ValueRef', args: 'functions.FunctionArgInput', line=-1):
+    def vcall(self, module: 'values.Field', graph: 'graphs.Graph', inst: 'values.ValueRef', args: 'functions.FunctionArgInput',
+              option: 'vevaluator.VEvalOption' = None, line=-1):
         assert(inst is None)
 
         funcArgs = self.args.merge_inputs(inst, args)
@@ -123,6 +126,13 @@ class ListFunction(functions.FunctionBase):
         else:
             node = nodes.NodeConvert('List', vargs[0], line)
             graph.add_node(node)
+
+            if vargs[0].has_constant_value():
+                refs = []
+                for attr_or_ref in vargs[0].internal_value:
+                    refs.append(utils.try_get_ref(attr_or_ref, 'list', utils.LineProperty()))
+
+                value.internal_value = refs
 
         value.name = '@F.{}.{}'.format(line, self.name)
         node.set_outputs([value])
@@ -137,7 +147,8 @@ class AppendFunction(functions.FunctionBase):
         self.args.add_arg('self', None)
         self.args.add_arg('elmnt', None)
 
-    def vcall(self, module: 'Field', graph: 'Graph', inst: 'values.ValueRef', args: 'functions.FunctionArgInput', line=-1):
+    def vcall(self, module: 'values.Field', graph: 'graphs.Graph', inst: 'values.ValueRef', args: 'functions.FunctionArgInput',
+              option: 'vevaluator.VEvalOption' = None, line=-1):
         funcArgs = self.args.merge_inputs(inst, args)
 
         node = nodes.NodeCall(self, funcArgs, line)
@@ -172,7 +183,8 @@ class KeysFunction(functions.FunctionBase):
         self.owner = owner
         self.args.add_arg('self', None)
 
-    def vcall(self, module: 'Field', graph: 'Graph', inst: 'values.ValueRef', args: 'functions.FunctionArgInput', line=-1):
+    def vcall(self, module: 'values.Field', graph: 'graphs.Graph', inst: 'values.ValueRef', args: 'functions.FunctionArgInput',
+              option: 'vevaluator.VEvalOption' = None, line=-1):
         funcArgs = self.args.merge_inputs(inst, args)
 
         if inst.in_container:
@@ -183,8 +195,8 @@ class KeysFunction(functions.FunctionBase):
         vargs = []
         vargs_value = []
         for varg in keys:
-            vargs.append(try_get_ref(varg, 'keys', utils.LineProperty()))
-            vargs_value.append(try_get_ref(varg, 'keys', utils.LineProperty()).get_value())
+            vargs.append(utils.try_get_ref(varg, 'dict_keys', utils.LineProperty()))
+            vargs_value.append(utils.try_get_ref(varg, 'dict_keys', utils.LineProperty()).get_value())
 
         node = nodes.NodeGenerate('List', vargs_value , line)
         graph.add_node(node)
@@ -202,7 +214,8 @@ class ValuesFunction(functions.FunctionBase):
         self.owner = owner
         self.args.add_arg('self', None)
 
-    def vcall(self, module: 'Field', graph: 'Graph', inst: 'values.ValueRef', args: 'functions.FunctionArgInput', line=-1):
+    def vcall(self, module: 'values.Field', graph: 'graphs.Graph', inst: 'values.ValueRef', args: 'functions.FunctionArgInput',
+              option: 'vevaluator.VEvalOption' = None, line=-1):
         funcArgs = self.args.merge_inputs(inst, args)
 
         if inst.in_container:
@@ -211,17 +224,19 @@ class ValuesFunction(functions.FunctionBase):
         key_hashes = inst.get_value().internal_keys.keys()
         attributes = inst.get_value().internal_values
         vargs = []
+        vargs_ref = []
         for hash in key_hashes:
             varg = attributes.get_attribute(hash)
             if varg.has_obj():
-                vargs.append(varg.get_ref().get_value())
+                vargs.append(utils.try_get_ref(varg, 'dict_values', utils.LineProperty()).get_value())
+                vargs_ref.append(utils.try_get_ref(varg, 'dict_values', utils.LineProperty()))
             else:
                 assert(False)
 
         node = nodes.NodeGenerate('List', vargs , line)
         graph.add_node(node)
 
-        value = values.ListValue()
+        value = values.ListValue(vargs_ref)
         value.name = '@F.{}.{}'.format(line, self.name)
         node.set_outputs([value])
         return value
@@ -234,7 +249,8 @@ class VEvalOptionFunction(functions.FunctionBase):
         self.args.analyze_args(func)
         self.flags = flags
 
-    def vcall(self, module: 'Field', graph: 'Graph', inst: 'values.ValueRef', args: 'functions.FunctionArgInput', line=-1):
+    def vcall(self, module: 'values.Field', graph: 'graphs.Graph', inst: 'values.ValueRef', args: 'functions.FunctionArgInput',
+              option: 'vevaluator.VEvalOption' = None, line=-1):
         assert(inst is None)
 
         funcArgs = self.args.merge_inputs(inst, args)
@@ -251,7 +267,8 @@ class GetAttrFunction(functions.FunctionBase):
         self.args.add_arg('object', None)
         self.args.add_arg('name', None)
 
-    def vcall(self, module: 'Field', graph: 'Graph', inst: 'values.ValueRef', args: 'functions.FunctionArgInput', line=-1):
+    def vcall(self, module: 'values.Field', graph: 'graphs.Graph', inst: 'values.ValueRef', args: 'functions.FunctionArgInput',
+              option: 'vevaluator.VEvalOption' = None, line=-1):
         func_args = self.args.merge_inputs(inst, args)
         name = func_args.get_value().get_value(key='name')
         obj = func_args.keywords['object']
@@ -261,7 +278,7 @@ class GetAttrFunction(functions.FunctionBase):
         # property(getter)
         if attr.has_obj() and isinstance(attr.get_ref().get_value(), values.FuncValue) and attr.get_ref().get_value().func.is_property:
             func_value = attr.get_ref().get_value()
-            ret = func_value.func.vcall(func_value.module, graph, func_value.obj, functions.FunctionArgInput(), lineprop)
+            ret = func_value.func.vcall(func_value.module, graph, func_value.obj, functions.FunctionArgInput(), option, lineprop)
             return ret
 
         if attr.has_obj():

--- a/chainer_compiler/elichika/parser/functions_builtin.py
+++ b/chainer_compiler/elichika/parser/functions_builtin.py
@@ -146,3 +146,20 @@ class AppendFunction(functions.FunctionBase):
 
         graph.add_node(node)
         return values.NoneValue()
+
+
+class VEvalOptionFunction(functions.FunctionBase):
+    def __init__(self, func, flags = None):
+        super().__init__()
+        self.name = func.__name__
+        self.args.analyze_args(func)
+        self.flags = flags
+
+    def vcall(self, module: 'Field', graph: 'Graph', inst: 'values.ValueRef', args: 'functions.FunctionArgInput', line=-1):
+        assert(inst is None)
+
+        funcArgs = self.args.merge_inputs(inst, args)
+        if self.flags is not None:
+            self.flags.append(self.name)
+
+        return values.ValueRef(values.NoneValue())

--- a/chainer_compiler/elichika/parser/functions_ndarray.py
+++ b/chainer_compiler/elichika/parser/functions_ndarray.py
@@ -15,7 +15,8 @@ class NDArrayInt32(functions.FunctionBase):
         super().__init__()
         self.name = 'int32'
         self.dtype = np.int32
-    def vcall(self, module: 'Field', graph: 'Graph', inst: 'values.ValueRef', args: 'functions.FunctionArgInput', line=-1):
+    def vcall(self, module: 'values.Field', graph: 'graphs.Graph', inst: 'values.ValueRef', args: 'functions.FunctionArgInput',
+              option: 'vevaluator.VEvalOption' = None, line=-1):
         assert(inst is None)
         return values.ValueRef(values.NoneValue)
 
@@ -25,7 +26,8 @@ class NDArrayFloat32(functions.FunctionBase):
         self.name = 'float32'
         self.dtype = np.float32
 
-    def vcall(self, module: 'Field', graph: 'Graph', inst: 'values.ValueRef', args: 'functions.FunctionArgInput', line=-1):
+    def vcall(self, module: 'values.Field', graph: 'graphs.Graph', inst: 'values.ValueRef', args: 'functions.FunctionArgInput',
+              option: 'vevaluator.VEvalOption' = None, line=-1):
         assert(inst is None)
         return values.ValueRef(values.NoneValue)
 
@@ -41,7 +43,8 @@ class NDArrayFunction(functions.FunctionBase):
         self.args.add_arg('subok', values.BoolValue(False))
         self.args.add_arg('ndmin', values.NumberValue(0))
 
-    def vcall(self, module: 'Field', graph: 'Graph', inst: 'values.ValueRef', args: 'functions.FunctionArgInput', line=-1):
+    def vcall(self, module: 'values.Field', graph: 'graphs.Graph', inst: 'values.ValueRef', args: 'functions.FunctionArgInput',
+              option: 'vevaluator.VEvalOption' = None, line=-1):
         assert(inst is None)
 
         funcArgs = self.args.merge_inputs(inst ,args)
@@ -79,7 +82,8 @@ class NDArrayZerosFunction(functions.FunctionBase):
         self.args.add_arg('dtype', values.NoneValue())
         self.args.add_arg('order', values.StrValue('C'))
 
-    def vcall(self, module: 'Field', graph: 'Graph', inst: 'values.ValueRef', args: 'functions.FunctionArgInput', line=-1):
+    def vcall(self, module: 'values.Field', graph: 'graphs.Graph', inst: 'values.ValueRef', args: 'functions.FunctionArgInput',
+              option: 'vevaluator.VEvalOption' = None, line=-1):
         assert(inst is None)
 
         funcArgs = self.args.merge_inputs(inst ,args)
@@ -116,7 +120,8 @@ class NDArrayFullFunction(functions.FunctionBase):
         self.args.add_arg('dtype', values.NoneValue())
         self.args.add_arg('order', values.StrValue('C'))
 
-    def vcall(self, module: 'Field', graph: 'Graph', inst: 'values.ValueRef', args: 'functions.FunctionArgInput', line=-1):
+    def vcall(self, module: 'values.Field', graph: 'graphs.Graph', inst: 'values.ValueRef', args: 'functions.FunctionArgInput',
+              option: 'vevaluator.VEvalOption' = None, line=-1):
         assert(inst is None)
 
         funcArgs = self.args.merge_inputs(inst ,args)
@@ -158,7 +163,8 @@ class NDArrayCeilFunction(functions.FunctionBase):
         self.name = 'ceil'
         self.args.add_arg('x', values.NoneValue())
 
-    def vcall(self, module: 'Field', graph: 'Graph', inst: 'values.ValueRef', args: 'functions.FunctionArgInput', line=-1):
+    def vcall(self, module: 'values.Field', graph: 'graphs.Graph', inst: 'values.ValueRef', args: 'functions.FunctionArgInput',
+              option: 'vevaluator.VEvalOption' = None, line=-1):
         assert(inst is None)
 
         funcArgs = self.args.merge_inputs(inst ,args)
@@ -180,7 +186,8 @@ class NDArrayCumsumFunction(functions.FunctionBase):
         self.args.add_arg('dtype', values.NoneValue())
         self.args.add_arg('out', values.NoneValue())
 
-    def vcall(self, module: 'Field', graph: 'Graph', inst: 'values.ValueRef', args: 'functions.FunctionArgInput', line=-1):
+    def vcall(self, module: 'values.Field', graph: 'graphs.Graph', inst: 'values.ValueRef', args: 'functions.FunctionArgInput',
+              option: 'vevaluator.VEvalOption' = None, line=-1):
         assert(inst is None)
 
         funcArgs = self.args.merge_inputs(inst ,args)
@@ -199,7 +206,8 @@ class NDArrayShapeFunction(functions.FunctionBase):
         self.name = 'shape'
         self.is_property = True
 
-    def vcall(self, module: 'Field', graph: 'Graph', inst: 'values.ValueRef', args: 'functions.FunctionArgInput', line=-1):
+    def vcall(self, module: 'values.Field', graph: 'graphs.Graph', inst: 'values.ValueRef', args: 'functions.FunctionArgInput',
+              option: 'vevaluator.VEvalOption' = None, line=-1):
         args = functions.FunctionArgInput()
         args.inputs.append(inst)
         args.keywords['self'] = inst
@@ -219,7 +227,8 @@ class NDArraySizeFunction(functions.FunctionBase):
         self.name = 'size'
         self.is_property = True
 
-    def vcall(self, module: 'Field', graph: 'Graph', inst: 'values.ValueRef', args: 'functions.FunctionArgInput', line=-1):
+    def vcall(self, module: 'values.Field', graph: 'graphs.Graph', inst: 'values.ValueRef', args: 'functions.FunctionArgInput',
+              option: 'vevaluator.VEvalOption' = None, line=-1):
         args = functions.FunctionArgInput()
         args.inputs.append(inst)
         args.keywords['self'] = inst

--- a/chainer_compiler/elichika/parser/links_builtin.py
+++ b/chainer_compiler/elichika/parser/links_builtin.py
@@ -1,7 +1,7 @@
 from chainer_compiler.elichika.parser import nodes
 from chainer_compiler.elichika.parser import values
 from chainer_compiler.elichika.parser import functions
-from chainer_compiler.elichika.parser.graphs import Graph
+from chainer_compiler.elichika.parser import graphs
 
 import chainer.links
 
@@ -89,7 +89,8 @@ class ChainerLinkFunction(functions.FunctionBase):
         self.name = '__call__'
         self.owner = owner
 
-    def vcall(self, module: 'values.Field', graph: 'Graph', inst: 'values.ValueRef', args: 'functions.FunctionArgInput', line=-1):
+    def vcall(self, module: 'values.Field', graph: 'graphs.Graph', inst: 'values.ValueRef', args: 'functions.FunctionArgInput',
+              option: 'vevaluator.VEvalOption' = None, line=-1):
 
         chainer_link = chainer_links[type(self.owner.inst)]
 
@@ -140,7 +141,8 @@ class ChainerChainListChildrenFunction(functions.FunctionBase):
         self.name = 'children'
         self.owner = owner
 
-    def vcall(self, module: 'Field', graph: 'Graph', inst: 'values.ValueRef', args: 'functions.FunctionArgInput', line=-1):
+    def vcall(self, module: 'values.Field', graph: 'graphs.Graph', inst: 'values.ValueRef', args: 'functions.FunctionArgInput',
+              option: 'vevaluator.VEvalOption' = None, line=-1):
         args = functions.FunctionArgInput()
         args.inputs.append(inst)
         args.keywords['self'] = inst

--- a/chainer_compiler/elichika/parser/nodes.py
+++ b/chainer_compiler/elichika/parser/nodes.py
@@ -17,6 +17,7 @@ class BinOpType(Enum):
     Mul = 2,
     Div = 3,
     FloorDiv = 4,
+    Mod = 5,
     Unknown = 255,
 
 

--- a/chainer_compiler/elichika/parser/utils.py
+++ b/chainer_compiler/elichika/parser/utils.py
@@ -107,3 +107,10 @@ class UnimplementedError(Exception):
 
     def __str__(self):
         return self.message + ' in ' + str(self.lineprop)
+
+class DummyFlag:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        return False

--- a/chainer_compiler/elichika/parser/utils.py
+++ b/chainer_compiler/elichika/parser/utils.py
@@ -1,6 +1,7 @@
 import os
 import numpy as np
 from chainer_compiler.elichika.parser import config
+from chainer_compiler.elichika.parser import values
 
 current_id = 0
 
@@ -83,6 +84,43 @@ def clip_head(s: 'str'):
     strs = map(lambda x: x[ls:], splitted)
     return '\n'.join(strs)
 
+def try_get_ref(value, name, lineprop) -> 'values.ValueRef':
+    if value is None:
+        print_warning('Failed to get value in "{}".'.format(name), lineprop)
+        return None
+
+    if isinstance(value, values.Value):
+        assert(False)
+
+    if isinstance(value, values.Attribute):
+        if value.has_obj():
+            return value.get_ref()
+
+    if isinstance(value, values.ValueRef):
+        return value
+
+    return None
+
+def try_get_value(value, name, lineprop, is_none_allowed = False) -> 'values.Value':
+    if value is None:
+        utils.print_warning('Failed to get value in "{}".'.format(name), lineprop)
+        return None
+
+    if isinstance(value, values.NoneValue) and not is_none_allowed:
+        if config.show_warnings:
+            print('Value {} is none. in {}'.format(name, lineprop))
+        return None
+
+    if isinstance(value, values.Value):
+        return value
+
+    if isinstance(value, values.ValueRef):
+        return value.get_value()
+
+    if isinstance(value, values.Attribute):
+        return value.get_ref().get_value()
+
+    raise Exception('Value {} is invalid. in L.{}'.format(name, lineprop))
 
 class LineProperty():
     def __init__(self, lineno=-1, filename=''):

--- a/chainer_compiler/elichika/parser/values.py
+++ b/chainer_compiler/elichika/parser/values.py
@@ -836,6 +836,7 @@ class ListValue(Value):
 class DictValue(Value):
     def __init__(self, keys=None, values=None):
         super().__init__()
+        # TODO(rchouras): Keys like 'True' and 1 map to same hash. This redundance need to be removed.
         self.internal_keys = keys
         self.internal_values = Field()
         self.key_dtype = None
@@ -859,7 +860,13 @@ class DictValue(Value):
     #     return
 
     def apply_to_object(self, obj: 'ValueRef'):
-        return
+        keys_func = ValueRef(
+            FuncValue(functions_builtin.KeysFunction(self), obj, None))
+        obj.attributes.get_attribute('keys').revise(keys_func)
+
+        values_func = ValueRef(
+            FuncValue(functions_builtin.ValuesFunction(self), obj, None))
+        obj.attributes.get_attribute('values').revise(values_func)
 
     def __str__(self):
         return self.name + '(D)'

--- a/chainer_compiler/elichika/parser/values.py
+++ b/chainer_compiler/elichika/parser/values.py
@@ -1000,3 +1000,7 @@ class UserDefinedInstance(Instance):
         exit_func = obj.try_get_and_store_obj('__exit__', None)
         if exit_func is not None:
             obj.get_field().get_attribute('__exit__').revise(exit_func)
+
+        getitem_func = obj.try_get_and_store_obj('__getitem__', None)
+        if getitem_func is not None:
+            obj.get_field().get_attribute('__getitem__').revise(getitem_func)

--- a/chainer_compiler/elichika/parser/values.py
+++ b/chainer_compiler/elichika/parser/values.py
@@ -182,6 +182,15 @@ def parse_instance(default_module, name, instance, self_instance=None, from_memb
         ret.estimate_type()
         return ValueRef(ret)
 
+    if isinstance(instance, dict):
+        keys = []
+        values = []
+        for key, value in instance.items():
+            keys.append(parse_instance(default_module, '', key))
+            values.append(parse_instance(default_module, '', value))
+        ret = DictValue(keys, values)
+        return ValueRef(ret)
+
     if isinstance(instance, tuple) and 'Undefined' in instance:
         shape = list(instance)
         shape = -1 if shape == 'Undefined' else shape

--- a/chainer_compiler/elichika/parser/values.py
+++ b/chainer_compiler/elichika/parser/values.py
@@ -836,8 +836,7 @@ class ListValue(Value):
 class DictValue(Value):
     def __init__(self, keys=None, values=None):
         super().__init__()
-        # TODO(rchouras): Keys like 'True' and 1 map to same hash. This redundance need to be removed.
-        self.internal_keys = keys
+        self.internal_keys = {}
         self.internal_values = Field()
         self.key_dtype = None
         self.key_vtype = None # type: Type
@@ -846,6 +845,7 @@ class DictValue(Value):
             if key.get_value().is_hashable():
                 key_hash = key.get_value().encode()
                 self.internal_values.get_attribute(key_hash).revise(value)
+                self.internal_keys[key_hash] = key
             else:
                 assert False  # Non hashable types not supported
 

--- a/chainer_compiler/elichika/parser/values.py
+++ b/chainer_compiler/elichika/parser/values.py
@@ -875,3 +875,14 @@ class UserDefinedInstance(Instance):
             obj = parse_instance(self.module, name, members_dict[name], inst, from_member=True, root_graph=root_graph)
 
         return obj
+
+    def apply_to_object(self, obj: 'values.ValueRef'):
+        super().apply_to_object(obj)
+
+        enter_func = obj.try_get_and_store_obj('__enter__', None)
+        if enter_func is not None:
+            obj.get_field().get_attribute('__enter__').revise(enter_func)
+
+        exit_func = obj.try_get_and_store_obj('__exit__', None)
+        if exit_func is not None:
+            obj.get_field().get_attribute('__exit__').revise(exit_func)

--- a/chainer_compiler/elichika/parser/veval_bin.py
+++ b/chainer_compiler/elichika/parser/veval_bin.py
@@ -69,6 +69,37 @@ def veval(op: 'nodes.BinOpType', left: 'values.Value', right: 'values.Value', li
     if isinstance(left, values.TupleValue):
         return functions.generate_value_with_same_type(left)
 
+    if isinstance(left, values.StrValue):
+        if not (isinstance(right, values.NumberValue) or isinstance(right, values.StrValue) or isinstance(right, values.BoolValue)
+            or isinstance(right, values.TupleValue)):
+            assert False
+
+        if not(left.has_constant_value() or right.has_constant_value()):
+            assert False
+
+        if op == nodes.BinOpType.Add:
+            if not isinstance(right, values.StrValue):
+                assert False
+            return values.StrValue(left.internal_value + right.internal_value)
+
+        elif op == nodes.BinOpType.Mod:
+            right_internal_value = right.internal_value
+
+            if isinstance(right, values.TupleValue):
+                values_ = []
+                for ref in right_internal_value:
+                    if not (isinstance(ref.get_value(), values.NumberValue) or isinstance(ref.get_value(), values.StrValue)
+                        or isinstance(ref.get_value(), values.BoolValue)):
+                        assert False
+                    if not ref.get_value().has_constant_value():
+                        assert False
+                    values_.append(ref.get_value())
+
+                right_internal_value = tuple(value.internal_value for value in values_)
+            return values.StrValue(left.internal_value % right_internal_value)
+
+        return values.StrValue("")
+
     if isinstance(right, values.NumberValue) or isinstance(right, values.TensorValue):
 
         if not isinstance(left, values.NumberValue) and not isinstance(left, values.TensorValue):

--- a/chainer_compiler/elichika/parser/vevaluator.py
+++ b/chainer_compiler/elichika/parser/vevaluator.py
@@ -75,6 +75,23 @@ def auto_set_unset(func, flag):
         return ret
     return decorated
 
+def return_value_or_ref(obj : 'value.Object'):
+    if isinstance(obj.get_value(), values.NumberValue):
+        return values.ValueRef(obj.get_value())
+
+    if isinstance(obj.get_value(), values.StrValue):
+        return values.ValueRef(obj.get_value())
+
+    if isinstance(obj.get_value(), values.BoolValue):
+        return values.ValueRef(obj.get_value())
+
+    if isinstance(obj.get_value(), values.NoneValue):
+        return values.ValueRef(obj.get_value())
+
+    if isinstance(obj.get_value(), values.TupleValue):
+        return values.ValueRef(obj.get_value())
+
+    return obj
 class AstContext:
     def __init__(self, nast, lineno_offset : 'int', filename : 'str' = '' ):
         self.nast = nast
@@ -176,24 +193,6 @@ def veval_ast_assign(astc : 'AstContext', local_field : 'values.Field', graph : 
 
     with option.eval_as_written_target():
         targets = veval_ast(astc.c(astc.nast.targets[0]), local_field, graph, option)
-
-    def return_value_or_ref(obj : 'value.Object'):
-            if isinstance(obj.get_value(), values.NumberValue):
-                return values.ValueRef(obj.get_value())
-
-            if isinstance(obj.get_value(), values.StrValue):
-                return values.ValueRef(obj.get_value())
-
-            if isinstance(obj.get_value(), values.BoolValue):
-                return values.ValueRef(obj.get_value())
-
-            if isinstance(obj.get_value(), values.NoneValue):
-                return values.ValueRef(obj.get_value())
-
-            if isinstance(obj.get_value(), values.TupleValue):
-                return values.ValueRef(obj.get_value())
-
-            return obj
 
     if isinstance(targets, list):
         # ex. a,b = (1,2)
@@ -1047,24 +1046,6 @@ def veval_ast_dict(astc : 'AstContext', local_field : 'values.Field', graph : 'G
     assert(isinstance(astc.nast, gast.gast.Dict))
     lineprop = utils.LineProperty(astc.lineno, astc.filename)
 
-    def return_value_or_ref(obj : 'value.Object'):
-        if isinstance(obj.get_value(), values.NumberValue):
-            return values.ValueRef(obj.get_value())
-
-        if isinstance(obj.get_value(), values.StrValue):
-            return values.ValueRef(obj.get_value())
-
-        if isinstance(obj.get_value(), values.BoolValue):
-            return values.ValueRef(obj.get_value())
-
-        if isinstance(obj.get_value(), values.NoneValue):
-            return values.ValueRef(obj.get_value())
-
-        if isinstance(obj.get_value(), values.TupleValue):
-            return values.ValueRef(obj.get_value())
-
-        return obj
-
     keys = []
     elts = []
 
@@ -1315,6 +1296,8 @@ def veval_ast_withitem(astc : 'AstContext', local_field : 'values.Field', graph 
         if config.show_warnings:
             print('It is possible that one of those withitem is invalid in L.{}'.format(astc.lineno))
         return None
+
+    value_obj = return_value_or_ref(value_obj)
 
     if astc.nast.optional_vars is not None:
         with option.eval_as_written_target():

--- a/chainer_compiler/elichika/parser/vevaluator.py
+++ b/chainer_compiler/elichika/parser/vevaluator.py
@@ -582,7 +582,7 @@ def veval_ast_subscript(astc : 'AstContext', local_field : 'values.Field', graph
         if isinstance(astc.nast.slice, gast.gast.Index):
             slice_ = veval_ast(astc.c(astc.nast.slice.value), local_field, graph, option)
             slice_value = try_get_value(slice_, 'subscript', lineprop)
-
+            value_value.internal_keys[slice_value.encode()] = slice_
             ret = value_value.internal_values.get_attribute(slice_value.encode())
             return ret
 

--- a/chainer_compiler/elichika/parser/vevaluator.py
+++ b/chainer_compiler/elichika/parser/vevaluator.py
@@ -158,7 +158,7 @@ def veval_ast_attribute(astc : 'AstContext', local_field : 'values.Field', graph
     lineprop = utils.LineProperty(astc.lineno, astc.filename)
 
     from_module = True
-    if option is not None and option.eval_as_written_target:
+    if option is not None and option._eval_as_written_target:
         from_module = False
 
     value = veval_ast(astc.c(astc.nast.value), local_field, graph, option)
@@ -184,7 +184,7 @@ def veval_ast_attribute(astc : 'AstContext', local_field : 'values.Field', graph
     if gotten_obj is not None:
         return value_ref.get_field().get_attribute(astc.nast.attr, graph.root_graph, from_module)
 
-    if option is not None and option.eval_as_written_target:
+    if option is not None and option._eval_as_written_target:
         return attr
         
     # value is unknown

--- a/chainer_compiler/elichika/parser/vevaluator.py
+++ b/chainer_compiler/elichika/parser/vevaluator.py
@@ -842,6 +842,8 @@ def veval_ast_bin_op(astc : 'AstContext', local_field : 'values.Field', graph : 
         binop = nodes.BinOpType.Div
     elif isinstance(astc.nast.op, gast.FloorDiv):
         binop = nodes.BinOpType.FloorDiv
+    elif isinstance(astc.nast.op, gast.Mod):
+        binop = nodes.BinOpType.Mod
     else:
         utils.print_warning('Unknown binary operator {}'.format(astc.nast.op), lineprop)
         return None

--- a/chainer_compiler/elichika/parser/vevaluator.py
+++ b/chainer_compiler/elichika/parser/vevaluator.py
@@ -1262,9 +1262,7 @@ def veval_ast_withitem(astc : 'AstContext', local_field : 'values.Field', graph 
     enter_attr = value_obj.get_field().get_attribute('__enter__', graph.root_graph, from_module)
     if enter_attr.has_obj() and isinstance(enter_attr.get_ref().get_value(), values.FuncValue):
         func_value = enter_attr.get_ref().get_value()
-        value_obj_ = func_value.func.vcall(func_value.module, graph, func_value.obj, functions.FunctionArgInput(), lineprop)
-
-    value_obj = value_obj_
+        value_obj = func_value.func.vcall(func_value.module, graph, func_value.obj, functions.FunctionArgInput(), lineprop)
 
     if value is None:
         if config.show_warnings:

--- a/chainer_compiler/elichika/parser/vevaluator.py
+++ b/chainer_compiler/elichika/parser/vevaluator.py
@@ -1260,7 +1260,7 @@ def veval_ast_with(astc : 'AstContext', local_field : 'values.Field', graph : 'G
 
     with ExitStack() as stack:
         managers = [stack.enter_context(getattr(option, flag)()) for flag in common_flags_cache]
-        if option._ignore_branch:
+        if not option._ignore_branch:
             veval_ast(astc.c(astc.nast.body), local_field, graph, option)
 
 def veval_ast_withitem(astc : 'AstContext', local_field : 'values.Field', graph : 'Graph', option : 'VEvalOption' = None):

--- a/chainer_compiler/elichika/parser/vevaluator.py
+++ b/chainer_compiler/elichika/parser/vevaluator.py
@@ -606,10 +606,10 @@ def veval_ast_subscript(astc : 'AstContext', local_field : 'values.Field', graph
                 node = nodes.NodeGetItem(value_value, [slice_value])
 
             if isinstance(value_value, values.ListValue) and value_value.vtype != None:
-                ret_value = value_value.vtype()
+                ret_value = value_value.vtype(None)
                 ret_value.dtype = value_value.dtype
             elif isinstance(value_value, values.TupleValue) and value_value.vtype != None:
-                ret_value = value_value.vtype()
+                ret_value = value_value.vtype(None)
                 ret_value.dtype = value_value.dtype
             else:
                 ret_value = values.UnknownValue()
@@ -1047,6 +1047,24 @@ def veval_ast_dict(astc : 'AstContext', local_field : 'values.Field', graph : 'G
     assert(isinstance(astc.nast, gast.gast.Dict))
     lineprop = utils.LineProperty(astc.lineno, astc.filename)
 
+    def return_value_or_ref(obj : 'value.Object'):
+        if isinstance(obj.get_value(), values.NumberValue):
+            return values.ValueRef(obj.get_value())
+
+        if isinstance(obj.get_value(), values.StrValue):
+            return values.ValueRef(obj.get_value())
+
+        if isinstance(obj.get_value(), values.BoolValue):
+            return values.ValueRef(obj.get_value())
+
+        if isinstance(obj.get_value(), values.NoneValue):
+            return values.ValueRef(obj.get_value())
+
+        if isinstance(obj.get_value(), values.TupleValue):
+            return values.ValueRef(obj.get_value())
+
+        return obj
+
     keys = []
     elts = []
 
@@ -1056,7 +1074,7 @@ def veval_ast_dict(astc : 'AstContext', local_field : 'values.Field', graph : 'G
         key_obj = try_get_ref(key_, 'dict', lineprop)
         elt_obj = try_get_ref(elt_,'dict', lineprop)
         keys.append(key_obj)
-        elts.append(elt_obj)
+        elts.append(return_value_or_ref(elt_obj))
 
     value = values.DictValue(keys, elts)
 

--- a/scripts/elichika_tests.py
+++ b/scripts/elichika_tests.py
@@ -95,6 +95,7 @@ TESTS = [
     Generator('syntax', 'UserDefinedFunc'),
     Generator('syntax', 'Tuple'),
     Generator('syntax', 'Print'),
+    Generator('syntax', 'With')
 ]
 
 

--- a/scripts/elichika_tests.py
+++ b/scripts/elichika_tests.py
@@ -95,7 +95,9 @@ TESTS = [
     Generator('syntax', 'UserDefinedFunc'),
     Generator('syntax', 'Tuple'),
     Generator('syntax', 'Print'),
-    Generator('syntax', 'With')
+    Generator('syntax', 'With'),
+    Generator('syntax', 'Dict'),
+    Generator('syntax', 'GetItem')
 ]
 
 

--- a/testcases/elichika_tests/syntax/Dict.py
+++ b/testcases/elichika_tests/syntax/Dict.py
@@ -6,14 +6,18 @@ import chainer
 class SimpleDictionary(chainer.Chain):
     def forward(self):
         x = {"one": 1, "two": 2}
-        return x["one"] * x["two"]
+        y = {1: 1, 2: 2, 1.0: 3}
+        return x["one"] * y[1]
 
 
 class DictionarySubscript(chainer.Chain):
-    def forward(self, key, value):
-        test_dict = {key: None}
-        test_dict[key] = value
-        return test_dict[key]
+    def forward(self):
+        test_dict = {}
+        value = 1
+        for key in [True, 2, "Three", 2, True, 1]:
+            test_dict[key] = value
+            value += 1
+        return test_dict[True] * test_dict[2] * test_dict["Three"]
 
 
 class DictonaryIterateKeys(chainer.Chain):
@@ -52,13 +56,10 @@ from itertools import product
 
 def main():
     testtools.generate_testcase(SimpleDictionary(), [], subname='simple_dictionary')
-    testtools.generate_testcase(DictonaryIterateKeys(), [], subname='dictionary_iterate_keys')
-    testtools.generate_testcase(DictonaryIterateValues(), [], subname='dictionary_iterate_values')
-    testtools.generate_testcase(DictonaryIterateItems(), [], subname='dictionary_iterate_items')
-
-    for key, value in product([1, "one", True], repeat=2):
-        testtools.generate_testcase(DictionarySubscript, [key, value], subname='dictionary_subscript_%s_%s' % (str(key), str(value)))
-
+    testtools.generate_testcase(DictionarySubscript, [], subname='dictionary_subscript')
+    # testtools.generate_testcase(DictonaryIterateKeys(), [], subname='dictionary_iterate_keys')
+    # testtools.generate_testcase(DictonaryIterateValues(), [], subname='dictionary_iterate_values')
+    # testtools.generate_testcase(DictonaryIterateItems(), [], subname='dictionary_iterate_items')
 
 
 if __name__ == '__main__':

--- a/testcases/elichika_tests/syntax/Dict.py
+++ b/testcases/elichika_tests/syntax/Dict.py
@@ -33,7 +33,7 @@ class DictionaryAssignByValueRef(chainer.Chain):
 
 class DictonaryIterateKeys(chainer.Chain):
     def forward(self):
-        x = {"one": 1, "two": 2, "three": 3, "four": 4}
+        x = {1: 1, "two": 2, 3: 3, "four": 4, True: 5}
         ret = 0
         for key in x.keys():
             ret += x[key]
@@ -42,7 +42,7 @@ class DictonaryIterateKeys(chainer.Chain):
 
 class DictonaryIterateValues(chainer.Chain):
     def forward(self):
-        x = {"one": 1, "two": 2, "three": 3, "four": 4}
+        x = {1: 1, "two": 2, 3: 3, "four": 4, True: 5}
         ret = 0
         for value in x.values():
             ret += value

--- a/testcases/elichika_tests/syntax/Dict.py
+++ b/testcases/elichika_tests/syntax/Dict.py
@@ -34,6 +34,7 @@ class DictionaryAssignByValueRef(chainer.Chain):
 class DictonaryIterateKeys(chainer.Chain):
     def forward(self):
         x = {1: 1, "two": 2, 3: 3, "four": 4, True: 5}
+        x["five"] = 5
         ret = 0
         for key in x.keys():
             ret += x[key]
@@ -43,6 +44,7 @@ class DictonaryIterateKeys(chainer.Chain):
 class DictonaryIterateValues(chainer.Chain):
     def forward(self):
         x = {1: 1, "two": 2, 3: 3, "four": 4, True: 5}
+        x["five"] = 5
         ret = 0
         for value in x.values():
             ret += value

--- a/testcases/elichika_tests/syntax/Dict.py
+++ b/testcases/elichika_tests/syntax/Dict.py
@@ -19,6 +19,17 @@ class DictionarySubscript(chainer.Chain):
             value += 1
         return test_dict[True] * test_dict[2] * test_dict["Three"]
 
+class DictionaryAssignByValueRef(chainer.Chain):
+    def forward(self):
+        # shared reference
+        list_ = [1]
+        test_dict1 = {"x": list_, "y": list_}
+        test_dict1["x"].append(2)
+        # shared value
+        num_ = 1
+        test_dict2 = {"x": num_, "y": num_}
+        test_dict2["x"] += 1
+        return test_dict1["y"][1] * test_dict2["y"]
 
 class DictonaryIterateKeys(chainer.Chain):
     def forward(self):
@@ -57,6 +68,7 @@ from itertools import product
 def main():
     testtools.generate_testcase(SimpleDictionary(), [], subname='simple_dictionary')
     testtools.generate_testcase(DictionarySubscript, [], subname='dictionary_subscript')
+    testtools.generate_testcase(DictionaryAssignByValueRef, [], subname='assign_by_value_ref')
     # testtools.generate_testcase(DictonaryIterateKeys(), [], subname='dictionary_iterate_keys')
     # testtools.generate_testcase(DictonaryIterateValues(), [], subname='dictionary_iterate_values')
     # testtools.generate_testcase(DictonaryIterateItems(), [], subname='dictionary_iterate_items')

--- a/testcases/elichika_tests/syntax/Dict.py
+++ b/testcases/elichika_tests/syntax/Dict.py
@@ -59,6 +59,21 @@ class DictonaryIterateItems(chainer.Chain):
             ret += value
         return ret
 
+class DictionaryInConstructor(chainer.Chain):
+    def __init__(self):
+        super(DictionaryInConstructor, self).__init__()
+        self.test_dict = {"x": 1, "y" : 2}
+
+    def forward(self):
+        return self.test_dict["x"]
+
+class DictionaryInfinitelyNested(chainer.Chain):
+    def forward(self):
+        x = {"one": 1}
+        x["two"] = x
+        return x["two"]["two"]["two"]["one"]
+
+
 # ======================================
 
 
@@ -73,6 +88,8 @@ def main():
     testtools.generate_testcase(DictionaryAssignByValueRef, [], subname='assign_by_value_ref')
     testtools.generate_testcase(DictonaryIterateKeys(), [], subname='dictionary_iterate_keys')
     testtools.generate_testcase(DictonaryIterateValues(), [], subname='dictionary_iterate_values')
+    testtools.generate_testcase(DictionaryInfinitelyNested(), [], subname='dictionary_nested')
+    testtools.generate_testcase(DictionaryInConstructor(), [], subname='dictionary_in_constructor')
     # testtools.generate_testcase(DictonaryIterateItems(), [], subname='dictionary_iterate_items')
 
 

--- a/testcases/elichika_tests/syntax/Dict.py
+++ b/testcases/elichika_tests/syntax/Dict.py
@@ -1,0 +1,65 @@
+# coding: utf-8
+
+import chainer
+
+
+class SimpleDictionary(chainer.Chain):
+    def forward(self):
+        x = {"one": 1, "two": 2}
+        return x["one"] * x["two"]
+
+
+class DictionarySubscript(chainer.Chain):
+    def forward(self, key, value):
+        test_dict = {key: None}
+        test_dict[key] = value
+        return test_dict[key]
+
+
+class DictonaryIterateKeys(chainer.Chain):
+    def forward(self):
+        x = {"one": 1, "two": 2, "three": 3, "four": 4}
+        ret = 0
+        for key in x.keys():
+            ret += x[key]
+        return ret
+
+
+class DictonaryIterateValues(chainer.Chain):
+    def forward(self):
+        x = {"one": 1, "two": 2, "three": 3, "four": 4}
+        ret = 0
+        for value in x.values():
+            ret += value
+        return ret
+
+
+class DictonaryIterateItems(chainer.Chain):
+    def forward(self):
+        x = {"one": 1, "two": 2, "three": 3, "four": 4}
+        ret = 0
+        for key, value in x.items():
+            ret += value
+        return ret
+
+# ======================================
+
+
+from chainer_compiler.elichika import testtools
+import numpy as np
+from itertools import product
+
+
+def main():
+    testtools.generate_testcase(SimpleDictionary(), [], subname='simple_dictionary')
+    testtools.generate_testcase(DictonaryIterateKeys(), [], subname='dictionary_iterate_keys')
+    testtools.generate_testcase(DictonaryIterateValues(), [], subname='dictionary_iterate_values')
+    testtools.generate_testcase(DictonaryIterateItems(), [], subname='dictionary_iterate_items')
+
+    for key, value in product([1, "one", True], repeat=2):
+        testtools.generate_testcase(DictionarySubscript, [key, value], subname='dictionary_subscript_%s_%s' % (str(key), str(value)))
+
+
+
+if __name__ == '__main__':
+    main()

--- a/testcases/elichika_tests/syntax/Dict.py
+++ b/testcases/elichika_tests/syntax/Dict.py
@@ -69,8 +69,8 @@ def main():
     testtools.generate_testcase(SimpleDictionary(), [], subname='simple_dictionary')
     testtools.generate_testcase(DictionarySubscript, [], subname='dictionary_subscript')
     testtools.generate_testcase(DictionaryAssignByValueRef, [], subname='assign_by_value_ref')
-    # testtools.generate_testcase(DictonaryIterateKeys(), [], subname='dictionary_iterate_keys')
-    # testtools.generate_testcase(DictonaryIterateValues(), [], subname='dictionary_iterate_values')
+    testtools.generate_testcase(DictonaryIterateKeys(), [], subname='dictionary_iterate_keys')
+    testtools.generate_testcase(DictonaryIterateValues(), [], subname='dictionary_iterate_values')
     # testtools.generate_testcase(DictonaryIterateItems(), [], subname='dictionary_iterate_items')
 
 

--- a/testcases/elichika_tests/syntax/For.py
+++ b/testcases/elichika_tests/syntax/For.py
@@ -78,6 +78,12 @@ class UpdateSelfLiteral(chainer.Chain):
             self.x += i
         return self.x
 
+class UnrollBasic(chainer.Chain):
+    def forward(self):
+        self.x = 42
+        for i in [0, 1, 2, 3, 4]:
+            self.x += i
+        return self.x
 
 class UpdateSelfLiteralInInit(chainer.Chain):
     def __init__(self):
@@ -176,6 +182,8 @@ def main():
     testtools.generate_testcase(UpdateSelf(), [42], subname='update_self')
 
     # testtools.generate_testcase(UpdateSelfLocal(), [], subname='update_self_local')
+
+    testtools.generate_testcase(UnrollBasic(), [], subname='for_unroll')
 
     testtools.generate_testcase(UpdateSelfLiteral(), [],
                                 subname='update_self_literal')

--- a/testcases/elichika_tests/syntax/GetItem.py
+++ b/testcases/elichika_tests/syntax/GetItem.py
@@ -1,0 +1,66 @@
+# coding: utf-8
+
+import chainer
+
+
+class GetItemSimple(chainer.Chain):
+    def __init__(self):
+        super(GetItemSimple, self).__init__()
+        self.x = 1
+
+    def forward(self):
+        self.y = 2
+        return self['x'] * self['y']
+
+class GetItemCustom(chainer.Chain):
+    def __init__(self):
+        super(GetItemCustom, self).__init__()
+        self.x = 1
+
+    def __getitem__(self, name):
+        self.x += 1
+        return getattr(self, name)
+
+    def forward(self):
+        self.y = 2
+        return self['x'] * self['y']
+
+
+class GetItemFunction(chainer.Chain):
+    def func(self, n):
+        return n
+
+    def forward(self):
+        self.x = 3
+        return self['func'](self['x'])
+
+
+class GetItemGetter(chainer.Chain):
+    def __init__(self):
+        super(GetItemGetter, self).__init__()
+        self._x = 1
+
+    @property
+    def x(self):
+        return self._x
+
+    def forward(self):
+        return self['x']
+
+
+# ======================================
+
+
+from chainer_compiler.elichika import testtools
+import numpy as np
+
+
+def main():
+    testtools.generate_testcase(GetItemSimple(), [], subname='GetItemSimple')
+    # testtools.generate_testcase(GetItemCustom(), [], subname='GetItemCustom')  # Bug in UserDefinedFunctions.
+    testtools.generate_testcase(GetItemFunction(), [], subname='GetItemFunction')
+    testtools.generate_testcase(GetItemGetter(), [], subname='GetItemGetter')
+
+
+if __name__ == '__main__':
+    main()

--- a/testcases/elichika_tests/syntax/GetItem.py
+++ b/testcases/elichika_tests/syntax/GetItem.py
@@ -47,6 +47,21 @@ class GetItemGetter(chainer.Chain):
     def forward(self):
         return self['x']
 
+class StrConstantPropagation(chainer.Chain):
+    def __init__(self):
+        super(StrConstantPropagation, self).__init__()
+        self.x1 = 1
+        self.x2 = 2
+        self.x3 = 3
+        self.x121hello1 = 4
+
+    def forward(self):
+        ret = 0
+        for i in [1, 2, 3]:
+            ret += self['x%d' % i]
+        ret += self['x%s' % '%d%s' % (121, "%s%d" % ("hello", True))]
+        return ret
+
 
 # ======================================
 
@@ -60,6 +75,7 @@ def main():
     # testtools.generate_testcase(GetItemCustom(), [], subname='GetItemCustom')  # Bug in UserDefinedFunctions.
     testtools.generate_testcase(GetItemFunction(), [], subname='GetItemFunction')
     testtools.generate_testcase(GetItemGetter(), [], subname='GetItemGetter')
+    testtools.generate_testcase(StrConstantPropagation(), [], subname='StrConstantPropagation')
 
 
 if __name__ == '__main__':

--- a/testcases/elichika_tests/syntax/With.py
+++ b/testcases/elichika_tests/syntax/With.py
@@ -55,11 +55,14 @@ class D(chainer.Chain):
         with Z(3) as obj:
             return obj
 
+def func_elichika_dislike():
+    yield 42
+
 class IgnoreBranch(chainer.Chain):
     def forward(self):
         ret = 0
         with flags.ignore_branch():
-            ret += 1
+            func_elichika_dislike()
         ret += 1
         return ret
 
@@ -100,7 +103,7 @@ def main():
     testtools.generate_testcase(B(), [], 'multiple')
     testtools.generate_testcase(C(), [], 'enter_exit')
     testtools.generate_testcase(D(), [], 'self_not_returned')
-    # testtools.generate_testcase(IgnoreBranch(), [], 'ignore_branch')
+    testtools.generate_testcase(IgnoreBranch(), [], 'ignore_branch')
     testtools.generate_testcase(ForUnroll(), [], 'for_unroll')
 
 if __name__ == '__main__':

--- a/testcases/elichika_tests/syntax/With.py
+++ b/testcases/elichika_tests/syntax/With.py
@@ -8,9 +8,11 @@ class F(object):
         self.a = a
 
     def __enter__(self):
+        self.a = self.a + 1
         return self
 
     def __exit__(self, type, value, traceback):
+        self.a = self.a + 2
         return False
 
 class A(chainer.Chain):
@@ -23,6 +25,14 @@ class B(chainer.Chain):
         ret = 0
         with F(3) as obj1, F(4) as obj2:
             ret = obj1.a + obj2.a
+        return ret
+
+class C(chainer.Chain):
+    def forward(self):
+        ret = 0
+        with F(3) as obj1, F(4) as obj2:
+            ret += obj1.a
+        ret +=  obj2.a
         return ret
 
 class IgnoreBranch(chainer.Chain):
@@ -43,6 +53,7 @@ import numpy as np
 def main():
     testtools.generate_testcase(A(), [], 'basic')
     testtools.generate_testcase(B(), [], 'multiple')
+    testtools.generate_testcase(C(), [], 'enter_exit')
     # testtools.generate_testcase(IgnoreBranch(), [], 'ignore_branch')
 
 

--- a/testcases/elichika_tests/syntax/With.py
+++ b/testcases/elichika_tests/syntax/With.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 
 import chainer
+from chainer_compiler.elichika.parser.flags import ignore_branch
 
 class F(object):
     def __init__(self, a):
@@ -24,6 +25,15 @@ class B(chainer.Chain):
             ret = obj1.a + obj2.a
         return ret
 
+class IgnoreBranch(chainer.Chain):
+    def forward(self):
+        ret = 0
+        with ignore_branch():
+            ret += 1
+        ret += 1
+        return ret
+
+
 # ======================================
 
 from chainer_compiler.elichika import testtools
@@ -33,6 +43,7 @@ import numpy as np
 def main():
     testtools.generate_testcase(A(), [], 'basic')
     testtools.generate_testcase(B(), [], 'multiple')
+    testtools.generate_testcase(IgnoreBranch(), [], 'ignore_branch')
 
 
 if __name__ == '__main__':

--- a/testcases/elichika_tests/syntax/With.py
+++ b/testcases/elichika_tests/syntax/With.py
@@ -1,12 +1,19 @@
 # coding: utf-8
 
 import chainer
-from chainer_compiler.elichika.parser.flags import ignore_branch
+from chainer_compiler.elichika.parser import flags
 
-class F(object):
+class X(object):
     def __init__(self, a):
         self.a = a
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        return False
+
+class Y(X):
     def __enter__(self):
         self.a = self.a + 1
         return self
@@ -15,30 +22,43 @@ class F(object):
         self.a = self.a + 2
         return False
 
+class Z(X):
+    def __enter__(self):
+        return self.a
+
+# ======================================
+
 class A(chainer.Chain):
     def forward(self):
-        with F(3) as obj:
+        with X(3) as obj:
             return obj.a
 
 class B(chainer.Chain):
     def forward(self):
         ret = 0
-        with F(3) as obj1, F(4) as obj2:
-            ret = obj1.a + obj2.a
+        with X(3) as obj1, X(4) as obj2:
+            ret += obj1.a
+        ret += obj2.a
         return ret
 
 class C(chainer.Chain):
     def forward(self):
         ret = 0
-        with F(3) as obj1, F(4) as obj2:
+        obj2 = Y(4)
+        with Y(3) as obj1:
             ret += obj1.a
         ret +=  obj2.a
         return ret
 
+class D(chainer.Chain):
+    def forward(self):
+        with Z(3) as obj:
+            return obj
+
 class IgnoreBranch(chainer.Chain):
     def forward(self):
         ret = 0
-        with ignore_branch():
+        with flags.ignore_branch():
             ret += 1
         ret += 1
         return ret
@@ -54,6 +74,7 @@ def main():
     testtools.generate_testcase(A(), [], 'basic')
     testtools.generate_testcase(B(), [], 'multiple')
     testtools.generate_testcase(C(), [], 'enter_exit')
+    testtools.generate_testcase(D(), [], 'self_not_returned')
     # testtools.generate_testcase(IgnoreBranch(), [], 'ignore_branch')
 
 

--- a/testcases/elichika_tests/syntax/With.py
+++ b/testcases/elichika_tests/syntax/With.py
@@ -90,6 +90,10 @@ class ForUnroll(chainer.Chain):
             for i in self.dict.values():
                 ret += 4 * self['x%d' % i]
 
+            with flags.for_unroll(unroll=False):
+                for i in range(5):
+                    ret += i
+
         return ret
 
 # ======================================

--- a/testcases/elichika_tests/syntax/With.py
+++ b/testcases/elichika_tests/syntax/With.py
@@ -43,7 +43,7 @@ import numpy as np
 def main():
     testtools.generate_testcase(A(), [], 'basic')
     testtools.generate_testcase(B(), [], 'multiple')
-    testtools.generate_testcase(IgnoreBranch(), [], 'ignore_branch')
+    # testtools.generate_testcase(IgnoreBranch(), [], 'ignore_branch')
 
 
 if __name__ == '__main__':

--- a/testcases/elichika_tests/syntax/With.py
+++ b/testcases/elichika_tests/syntax/With.py
@@ -1,0 +1,39 @@
+# coding: utf-8
+
+import chainer
+
+class F(object):
+    def __init__(self, a):
+        self.a = a
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        return False
+
+class A(chainer.Chain):
+    def forward(self):
+        with F(3) as obj:
+            return obj.a
+
+class B(chainer.Chain):
+    def forward(self):
+        ret = 0
+        with F(3) as obj1, F(4) as obj2:
+            ret = obj1.a + obj2.a
+        return ret
+
+# ======================================
+
+from chainer_compiler.elichika import testtools
+import numpy as np
+
+
+def main():
+    testtools.generate_testcase(A(), [], 'basic')
+    testtools.generate_testcase(B(), [], 'multiple')
+
+
+if __name__ == '__main__':
+    main()

--- a/testcases/elichika_tests/syntax/With.py
+++ b/testcases/elichika_tests/syntax/With.py
@@ -63,6 +63,31 @@ class IgnoreBranch(chainer.Chain):
         ret += 1
         return ret
 
+class ForUnroll(chainer.Chain):
+    def __init__(self):
+        super(ForUnroll, self).__init__()
+        self.x1 = 1
+        self.x2 = 2
+        self.x3 = 3
+        self.dict = {'x1': 1, 'x2': 2, 'x3': 3}
+
+    def forward(self):
+        ret = 0
+
+        with flags.for_unroll():
+            for i in list([1, 2, 3]):
+                ret += 1 * self['x%d' % i]
+
+            for i in range(1, 4):
+                ret += 2 * self['x%d' % i]
+
+            for i in self.dict.keys():
+                ret += 3 * self[i]
+
+            for i in self.dict.values():
+                ret += 4 * self['x%d' % i]
+
+        return ret
 
 # ======================================
 
@@ -76,7 +101,7 @@ def main():
     testtools.generate_testcase(C(), [], 'enter_exit')
     testtools.generate_testcase(D(), [], 'self_not_returned')
     # testtools.generate_testcase(IgnoreBranch(), [], 'ignore_branch')
-
+    testtools.generate_testcase(ForUnroll(), [], 'for_unroll')
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
- [x] Update `VEvalOption` class.
- [x] Add user side support for dummy veval option flags.
- [x] Add Support for `with` syntax. (User defined managers need additional support for `__enter__` and `__exit__` calls)
- [x] Add support for 'Dict' syntax(1/2). (Dictionary declaration, setter and getter)
- [x] Add support for 'Dict' syntax(2/2). (Dictionary functions like items, keys, ~~values~~)
- [x] Add support for `ignore_branch` flag.
- [x] Add support for subscript on self. (Like `self['lstm1']`)
- [x] Add support for `for_unroll` flag.
- [x] Add constant string propagation for % operator.
- [x] Add tests for Dictionary support.
- [x] Add tests for existing `for` unroll. (When the iterator list consists of only constants)
- [x] Add tests for `ignore_branch` flag. ~~(Add tests for testing mismatch in output)~~
- [x] Add tests for `for_unroll` flag.