### PR TITLE
Modify examples so that arbitrary batch-size can be specified when training

### DIFF
--- a/examples/imagenet/train_imagenet_multi.py
+++ b/examples/imagenet/train_imagenet_multi.py
@@ -71,9 +71,12 @@ class ValTransform(object):
 class FixedBatchDataset(chainer.dataset.DatasetMixin):
     # Make the dataset size multiple of the batch-size by augmentation
 
-    def __init__(self, dataset, batchsize):
+    def __init__(self, dataset, batchsize, ignore_label=-1):
+        # `ignore_label` should be consistent with
+        # https://docs.chainer.org/en/stable/reference/generated/chainer.functions.softmax_cross_entropy.html
         self.dataset = dataset
         self.batchsize = batchsize
+        self.ignore_label = ignore_label
         d = len(self.dataset)
         self._len = ((d + batchsize - 1) // batchsize) * batchsize
 
@@ -85,7 +88,7 @@ class FixedBatchDataset(chainer.dataset.DatasetMixin):
             return self.dataset[idx]
         else:
             x_dummy, _ = self.dataset[0]
-            t_dummy = -1
+            t_dummy = self.ignore_label
             return x_dummy, t_dummy
 
 

--- a/examples/imagenet/train_imagenet_multi.py
+++ b/examples/imagenet/train_imagenet_multi.py
@@ -81,7 +81,12 @@ class FixedBatchDataset(chainer.dataset.DatasetMixin):
         return self._len
 
     def get_example(self, idx):
-        return self.dataset[idx % len(self.dataset)]
+        if idx < len(self.dataset):
+            return self.dataset[idx]
+        else:
+            x_dummy, _ = self.dataset[0]
+            t_dummy = -1
+            return x_dummy, t_dummy
 
 
 def main():

--- a/examples/imagenet/train_imagenet_multi.py
+++ b/examples/imagenet/train_imagenet_multi.py
@@ -123,6 +123,10 @@ def main():
     parser.add_argument('--weight-decay', type=float, default=0.0001)
     parser.add_argument('--out', type=str, default='result')
     parser.add_argument('--epoch', type=int, default=90)
+    parser.add_argument('--no_use_fixed_batch_dataset',
+                        dest='use_fixed_batch_dataset',
+                        action='store_false',
+                        help='Disable the use of FixedBatchDataset')
     args = parser.parse_args()
 
     # https://docs.chainer.org/en/stable/chainermn/tutorial/tips_faqs.html#using-multiprocessiterator
@@ -202,8 +206,9 @@ def main():
     val_indices = chainermn.scatter_dataset(val_indices, comm, shuffle=True)
     train_data = train_data.slice[train_indices]
     val_data = val_data.slice[val_indices]
-    train_data = FixedBatchDataset(train_data, args.batchsize)
-    val_data = FixedBatchDataset(val_data, args.batchsize)
+    if args.use_fixed_batch_dataset:
+        train_data = FixedBatchDataset(train_data, args.batchsize)
+        val_data = FixedBatchDataset(val_data, args.batchsize)
     train_iter = chainer.iterators.MultiprocessIterator(
         train_data, args.batchsize, n_processes=args.loaderjob)
     val_iter = iterators.MultiprocessIterator(

--- a/examples/mnist/train_mnist.py
+++ b/examples/mnist/train_mnist.py
@@ -108,6 +108,10 @@ def main():
     parser.add_argument('--use_unified_memory', dest='use_unified_memory',
                         action='store_true',
                         help='Use unified memory for large model')
+    parser.add_argument('--no_use_fixed_batch_dataset',
+                        dest='use_fixed_batch_dataset',
+                        action='store_false',
+                        help='Disable the use of FixedBatchDataset')
     args = parser.parse_args()
 
     device = chainer.get_device(args.device)
@@ -159,10 +163,9 @@ def main():
     else:
         train, test = chainer.datasets.get_mnist()
 
-    # WARN: The use of FixedBatchDataset to validation data will slightly alter
-    # the evaluation of validation loss and accuracy.
-    train = FixedBatchDataset(train, args.batchsize)
-    test = FixedBatchDataset(test, args.batchsize)
+    if args.use_fixed_batch_dataset:
+        train = FixedBatchDataset(train, args.batchsize)
+        test = FixedBatchDataset(test, args.batchsize)
 
     train_iter = chainer.iterators.SerialIterator(train, args.batchsize)
     test_iter = chainer.iterators.SerialIterator(test, args.batchsize,

--- a/examples/mnist/train_mnist.py
+++ b/examples/mnist/train_mnist.py
@@ -43,7 +43,12 @@ class FixedBatchDataset(chainer.dataset.DatasetMixin):
         return self._len
 
     def get_example(self, idx):
-        return self.dataset[idx % len(self.dataset)]
+        if idx < len(self.dataset):
+            return self.dataset[idx]
+        else:
+            x_dummy, _ = self.dataset[0]
+            t_dummy = -1
+            return x_dummy, t_dummy
 
 
 def fake_dataset():

--- a/examples/mnist/train_mnist.py
+++ b/examples/mnist/train_mnist.py
@@ -33,9 +33,12 @@ class MLP(chainer.Chain):
 class FixedBatchDataset(chainer.dataset.DatasetMixin):
     # Make the dataset size multiple of the batch-size by augmentation
 
-    def __init__(self, dataset, batchsize):
+    def __init__(self, dataset, batchsize, ignore_label=-1):
+        # `ignore_label` should be consistent with
+        # https://docs.chainer.org/en/stable/reference/generated/chainer.functions.softmax_cross_entropy.html
         self.dataset = dataset
         self.batchsize = batchsize
+        self.ignore_label = ignore_label
         d = len(self.dataset)
         self._len = ((d + batchsize - 1) // batchsize) * batchsize
 
@@ -47,7 +50,7 @@ class FixedBatchDataset(chainer.dataset.DatasetMixin):
             return self.dataset[idx]
         else:
             x_dummy, _ = self.dataset[0]
-            t_dummy = -1
+            t_dummy = self.ignore_label
             return x_dummy, t_dummy
 
 


### PR DESCRIPTION
`python examples/mnist/train_mnist.py --compile mymodel.onnx -b 101` will become possible.