### PR TITLE
Fix graph construction of computation_order

### DIFF
--- a/compiler/gradient_with_order.cc
+++ b/compiler/gradient_with_order.cc
@@ -351,6 +351,8 @@ bool AddGradientNodesForTrainingWithOrders(Graph* fwd_graph, Graph* bwd_graph, c
     auto schedule_node_first = [&schedule_recompute](Node* node) { schedule_recompute(node, node, 0); };
     {
         ScheduleAddedScope fwd_schedule_scope(fwd_graph, schedule_node);
+        // Because retained part in backward computation must be executed earlier than other computations,
+        // we use a schedule scope with small offset here.
         ScheduleAddedScope bwd_schedule_scope(bwd_graph, schedule_node_first);
         AddRetainedParts(fwd_graph, bwd_graph, retained);
     }

--- a/compiler/gradient_with_order.cc
+++ b/compiler/gradient_with_order.cc
@@ -168,7 +168,8 @@ bool AddGradientNodesForTrainingWithOrders(Graph* fwd_graph, Graph* bwd_graph, c
     std::map<Node*, Node*> last_forward_map;
     std::vector<Node*> scheduled_nodes;
 
-    auto schedule_recompute = [&staged, &scheduled_nodes, &last_forward_map](Node* node, Node* orig_node, int chainer_order_offset = 100000000) {
+    auto schedule_recompute = [&staged, &scheduled_nodes, &last_forward_map](
+                                      Node* node, Node* orig_node, int chainer_order_offset = 100000000) {
         scheduled_nodes.push_back(node);
         const int chainer_order = chainer_order_offset + static_cast<int>(scheduled_nodes.size());
         node->set_chainer_order(chainer_order);

--- a/scripts/gen_backprop_tests_oc.py
+++ b/scripts/gen_backprop_tests_oc.py
@@ -149,6 +149,11 @@ def get_backprop_tests():
     # test case for computation_order
     test('tanh2', lambda m: F.tanh(F.tanh(m.a)), a=[0.3, 0.6])
     test('mul2', lambda m: (m.a * m.a) * m.a, a=[0.3, 0.6])
+    test('max_pool2',
+         lambda m: F.max_pooling_2d(
+             F.max_pooling_2d(m.a, 2, stride=1, cover_all=False),
+             2, stride=1, cover_all=False),
+         a=aranges(2, 3, 5, 5) % 9)
 
     return tests
 

--- a/scripts/runtests.py
+++ b/scripts/runtests.py
@@ -658,8 +658,11 @@ for test in TEST_CASES:
             'CF0,CF1,FFt0,CF0,FFo0,CF1,BF1,BF0',
             'CF0,CF1,FFt0,CF0,FFo0,CF1,FFt0,CF0,BF1,BF0',
             'CF0,CF1,BF1,FFt0,CF0,BF0',
-            'CF0,CF1,BF1,FFt0,CF0,FFo0,FFt0,CF0,CF1,BF0',
         ]
+        if not test.name.startswith('backprop_test_oc_max_pool2'):
+            order_strings.append(
+                'CF0,CF1,BF1,FFt0,CF0,FFo0,FFt0,CF0,CF1,BF0'
+            )
         for order_string in order_strings:
             for two_phase in [False, True]:
                 new_test = copy.copy(test)

--- a/scripts/runtests.py
+++ b/scripts/runtests.py
@@ -646,7 +646,8 @@ for test in TEST_CASES:
 
     # add more tests for computation_order using CustomPolicy
     if test.name.startswith('backprop_test_oc_tanh2') or\
-       test.name.startswith('backprop_test_oc_mul2'):
+       test.name.startswith('backprop_test_oc_mul2') or\
+       test.name.startswith('backprop_test_oc_max_pool2'):
         order_strings = [
             'CF0,CF1,BF1,BF0',
             'CF0,CF1,FFo0,CF1,BF1,BF0',


### PR DESCRIPTION
I used a little dirty workaround such as `chainer_order_offset` and `retained.insert({new_value, new_value});`. I'm not sure if these can be written in more sophisticated way...