### PR TITLE
Initialize global variables at the beginning of CompiledModel

### DIFF
--- a/chainer_compiler/chainer_compiler.py
+++ b/chainer_compiler/chainer_compiler.py
@@ -237,6 +237,11 @@ class CompiledModel(chainer.Chain):
         self.compile(onnx_file)
 
     def compile(self, onnx_file):
+        compiler_kwargs = {'skip_inference': True}
+        if self.compiler_kwargs is not None:
+            compiler_kwargs.update(self.compiler_kwargs)
+        _chainer_compiler_core.configure(**compiler_kwargs)
+
         graph = _chainer_compiler_core.load(onnx_file)
         self.orig_output_names = graph.output_names()
 
@@ -261,15 +266,9 @@ class CompiledModel(chainer.Chain):
         self.fwd_output_names = fwd_graph.output_names()
         self.bwd_input_names = bwd_graph.input_names()
         self.bwd_output_names = bwd_graph.output_names()
-        compiler_kwargs = {
-            'skip_scheduling': skip_scheduling,
-            'skip_inference': True
-        }
-        if self.compiler_kwargs is not None:
-            compiler_kwargs.update(self.compiler_kwargs)
         # TODO(hamaji): Revive shape inference.
-        self.fwd = fwd_graph.compile(**compiler_kwargs)
-        self.bwd = bwd_graph.compile(**compiler_kwargs)
+        self.fwd = fwd_graph.compile(skip_scheduling)
+        self.bwd = bwd_graph.compile(skip_scheduling)
         self.param_names = fwd_graph.param_names()
 
         if self.used_translator == 'ch2o':

--- a/chainer_compiler_cc/chainer_compiler_core.cc
+++ b/chainer_compiler_cc/chainer_compiler_core.cc
@@ -55,7 +55,7 @@ std::map<std::string, VarPtr> LoadParams(const std::shared_ptr<Graph>& graph) {
 
 void Configure(
 #include "chainer_compiler_cc/cxx_args.inc"
-) {
+){
 #include "chainer_compiler_cc/apply_cxx_args.inc"
 }
 

--- a/chainer_compiler_cc/chainer_compiler_core.cc
+++ b/chainer_compiler_cc/chainer_compiler_core.cc
@@ -53,12 +53,13 @@ std::map<std::string, VarPtr> LoadParams(const std::shared_ptr<Graph>& graph) {
     return params;
 }
 
-std::shared_ptr<runtime::ChxVM> Compile(
-        const std::shared_ptr<Graph>& graph, bool skip_scheduling,
+void Configure(
 #include "chainer_compiler_cc/cxx_args.inc"
 ) {
 #include "chainer_compiler_cc/apply_cxx_args.inc"
+}
 
+std::shared_ptr<runtime::ChxVM> Compile(const std::shared_ptr<Graph>& graph, bool skip_scheduling) {
     constexpr bool kBackprop = false;
     RunDefaultPasses(graph.get(), kBackprop, skip_scheduling);
     runtime::XCProgramProto chxvm_prog;
@@ -145,9 +146,7 @@ std::string Dump(const std::shared_ptr<Graph>& graph) {
 void InitGraph(py::module& m) {
     py::class_<Graph, std::shared_ptr<Graph>> c{m, "Graph"};
     c.def("params", &LoadParams, "Load parameters of a model");
-    c.def("compile", &Compile, "Compile a model", "skip_scheduling"_a = false,
-#include "chainer_compiler_cc/pybind_args.inc"
-    );
+    c.def("compile", &Compile, "Compile a model", "skip_scheduling"_a = false);
     c.def("input_names", &GetInputNames, "Names of inputs");
     c.def("param_names", &GetParamNames, "Names of params");
     c.def("output_names", &GetOutputNames, "Names of outputs");
@@ -392,6 +391,9 @@ PYBIND11_MODULE(_chainer_compiler_core, m) {  // NOLINT
     InitChxVMState(m);
 
     m.def("load", &LoadGraph, "Load an ONNX model");
+    m.def("configure", &Configure, "Configure global variables in chainer compiler",
+#include "chainer_compiler_cc/pybind_args.inc"
+    );
     m.def("value", &CreateValueFromArray, "Create an ChxVMVar from a ChainerX Array");
     m.def("value", &CreateValueFromSequence, "Create an ChxVMVar from a sequence of ChxVMVars");
 }


### PR DESCRIPTION
In current implementation, global variables will be initialized when `fwd_graph.compile(...)` is called.
However, some variables such as `chen_budget` need to be initialized before this part.
I split the variable-initialization part from `Compile` function so that we can initialize global variables at the beginning of `CompiledModel`.