### PR TITLE
Fix skip_inference option in python

### DIFF
--- a/chainer_compiler/chainer_compiler.py
+++ b/chainer_compiler/chainer_compiler.py
@@ -311,7 +311,7 @@ class CompiledModel(chainer.Chain):
 
         runtime_kwargs = {}
         if (self.runtime_kwargs is not None and
-            self.num_iterations % (self.quiet_period + 1) == 0):
+           self.num_iterations % (self.quiet_period + 1) == 0):
             runtime_kwargs.update(self.runtime_kwargs)
         self.num_iterations += 1
 

--- a/chainer_compiler/chainer_compiler.py
+++ b/chainer_compiler/chainer_compiler.py
@@ -311,7 +311,7 @@ class CompiledModel(chainer.Chain):
 
         runtime_kwargs = {}
         if (self.runtime_kwargs is not None and
-           self.num_iterations % (self.quiet_period + 1) == 0):
+            self.num_iterations % (self.quiet_period + 1) == 0):
             runtime_kwargs.update(self.runtime_kwargs)
         self.num_iterations += 1
 

--- a/chainer_compiler/chainer_compiler.py
+++ b/chainer_compiler/chainer_compiler.py
@@ -260,7 +260,10 @@ class CompiledModel(chainer.Chain):
                              '\n=== ^^^ backward ^^^ ===\n')
 
         # TODO(hamaji): Revive shape inference.
-        _chainer_compiler_core.configure(skip_inference=True)
+        compiler_kwargs = {'skip_inference': True}
+        if self.compiler_kwargs is not None:
+            compiler_kwargs.update(self.compiler_kwargs)
+        _chainer_compiler_core.configure(**compiler_kwargs)
 
         assert graph.input_names() == fwd_graph.input_names()
         self.fwd_input_names = fwd_graph.input_names()

--- a/chainer_compiler/chainer_compiler.py
+++ b/chainer_compiler/chainer_compiler.py
@@ -238,10 +238,8 @@ class CompiledModel(chainer.Chain):
 
     def compile(self, onnx_file):
         # TODO(hamaji): Revive shape inference.
-        compiler_kwargs = {'skip_inference': True}
         if self.compiler_kwargs is not None:
-            compiler_kwargs.update(self.compiler_kwargs)
-        _chainer_compiler_core.configure(**compiler_kwargs)
+            _chainer_compiler_core.configure(**self.compiler_kwargs)
 
         graph = _chainer_compiler_core.load(onnx_file)
         self.orig_output_names = graph.output_names()
@@ -261,6 +259,8 @@ class CompiledModel(chainer.Chain):
             sys.stderr.write('=== vvv backward vvv ===\n' +
                              bwd_graph.dump() +
                              '\n=== ^^^ backward ^^^ ===\n')
+
+        _chainer_compiler_core.configure(skip_inference=True)
 
         assert graph.input_names() == fwd_graph.input_names()
         self.fwd_input_names = fwd_graph.input_names()

--- a/chainer_compiler/chainer_compiler.py
+++ b/chainer_compiler/chainer_compiler.py
@@ -237,7 +237,6 @@ class CompiledModel(chainer.Chain):
         self.compile(onnx_file)
 
     def compile(self, onnx_file):
-        # TODO(hamaji): Revive shape inference.
         if self.compiler_kwargs is not None:
             _chainer_compiler_core.configure(**self.compiler_kwargs)
 
@@ -260,6 +259,7 @@ class CompiledModel(chainer.Chain):
                              bwd_graph.dump() +
                              '\n=== ^^^ backward ^^^ ===\n')
 
+        # TODO(hamaji): Revive shape inference.
         _chainer_compiler_core.configure(skip_inference=True)
 
         assert graph.input_names() == fwd_graph.input_names()


### PR DESCRIPTION
#508 caused a bug: computation_order option will not work from python code.
This PR will fix the issue.