### PR TITLE
Fix to avoid to install onnxruntime

### DIFF
--- a/.chainerci/before_install.sh
+++ b/.chainerci/before_install.sh
@@ -8,14 +8,14 @@ nvidia-smi
 
 python3 -m pip install gast chainercv packaging
 CHAINER_VERSION=$(python3 -c "import imp;print(imp.load_source('_version','third_party/chainer/chainer/_version.py').__version__)")
-python3 -m pip install cupy-cuda100==$CHAINER_VERSION
+python3 -m pip install cupy-cuda101==$CHAINER_VERSION
 
 CHAINER_BUILD_CHAINERX=1 CHAINERX_BUILD_CUDA=1 MAKEFLAGS=-j8 \
     CHAINERX_NVCC_GENERATE_CODE=arch=compute_70,code=sm_70 \
     python3 -m pip -q install --no-cache-dir third_party/chainer[test]
 # TODO(take-cheeze): Remove this when onnx-chainer drops 1.4.1 support
 python3 -m pip install onnx==1.5.0
-python3 -m pip install --no-cache-dir third_party/onnx-chainer[test-gpu]
+python3 -m pip install --no-cache-dir third_party/onnx-chainer[test]
 
 python3 -m pip list -v
 

--- a/scripts/run-travis-tests.sh
+++ b/scripts/run-travis-tests.sh
@@ -17,8 +17,8 @@ run() {
     travis_fold end $n
 }
 
-run pip_chainer sudo pip3 install third_party/chainer
-run pip_onnx_chainer sudo pip3 install -U -e third_party/onnx-chainer[travis]
+run pip_chainer sudo pip3 install third_party/chainer[test]
+run pip_onnx_chainer sudo pip3 install -U -e third_party/onnx-chainer[test]
 
 run pip_list pip3 list -v
 


### PR DESCRIPTION
`third_party/onnx-chainer[test]`: install pytest and ChaienrCV
`third_party/chainer` -> `third_party/chainer[test]`: to install pytest supported by Chainer before installing ONNX-Chainer