### PR TITLE
Move recompute input to backprop graph lazily

### DIFF
--- a/compiler/gradient_with_order.cc
+++ b/compiler/gradient_with_order.cc
@@ -201,6 +201,7 @@ bool AddGradientNodesForTrainingWithOrders(Graph* fwd_graph, Graph* bwd_graph, c
     size_t num_forwards = 0;
     size_t num_recomputes = 0;
     size_t num_forgets = 0;
+    std::set<Value*> staged_in_forward;
 
     for (size_t i = 0; i < orders.size(); ++i) {
         const Order& order = orders[i];
@@ -218,16 +219,8 @@ bool AddGradientNodesForTrainingWithOrders(Graph* fwd_graph, Graph* bwd_graph, c
                     ScheduleAddedScope bwd_schedule_scope(bwd_graph, schedule_node);
                     AddGradInputs(fwd_graph, bwd_graph);
 
-                    // Create a retained value for the backward part
                     for (auto& p : staged) {
-                        Value* new_value = bwd_graph->AddValue("RetainedForRecompute_" + p.first->name(), p.first->type());
-                        p.second = new_value;
-                        retained.insert({p.first, new_value});
-                        retained.insert({new_value, new_value});  // Avoid retaining new_value during backward computation
-
-                        if (p.first->IsOutput()) {
-                            new_value->set_grad(p.first->grad());
-                        }
+                        CHECK(staged_in_forward.insert(p.second).second);
                     }
                 }
             }
@@ -254,8 +247,26 @@ bool AddGradientNodesForTrainingWithOrders(Graph* fwd_graph, Graph* bwd_graph, c
                     ++num_recomputes;
                     // Recomputation: current graph must be the backward part
                     CHECK_EQ(current_graph, bwd_graph);
+
                     // All inputs must be staged and may be recomputed.
-                    const std::vector<Value*> inputs = GetStagedValues(staged, node->inputs());
+                    std::vector<Value*> inputs = GetStagedValues(staged, node->inputs());
+                    for (size_t i = 0; i < inputs.size(); ++i) {
+                        Value* value = inputs[i];
+                        if (!staged_in_forward.count(value)) {
+                            continue;
+                        }
+
+                        Value* value_in_bwd = bwd_graph->AddValue("RetainedForRecompute_" + value->name(), value->type());
+                        retained.insert({value, value_in_bwd});
+                        // Avoid retaining new_value during backward computation.
+                        retained.insert({value_in_bwd, value_in_bwd});
+
+                        if (value->IsOutput()) {
+                            value_in_bwd->set_grad(value->grad());
+                        }
+                        staged[value] = value_in_bwd;
+                        inputs[i] = value_in_bwd;
+                    }
 
                     // Recomputed values need different `Value`
                     // objects with different names.
@@ -263,7 +274,8 @@ bool AddGradientNodesForTrainingWithOrders(Graph* fwd_graph, Graph* bwd_graph, c
                     for (Value* value : node->outputs()) {
                         Value* new_value = bwd_graph->AddValue("Recompute" + value->name(), value->type());
                         outputs.push_back(new_value);
-                        retained.insert({new_value, new_value});  // Avoid retaining new_value during backward computation
+                        // Avoid retaining new_value during backward computation.
+                        retained.insert({new_value, new_value});
                     }
 
                     // Copy the original computation node to generate


### PR DESCRIPTION
For ResNet50 fwd peak/bwd peak with 100MB budget
- Chen: 145/158 => 105/158
- GT: 197/197 => 173/182