### PR TITLE
Use CLOG instead of std::cerr in gradient part

### DIFF
--- a/compiler/computation_order/policy_chen.cc
+++ b/compiler/computation_order/policy_chen.cc
@@ -12,6 +12,7 @@
 
 #include <compiler/flags.h>
 #include <compiler/graph.h>
+#include <compiler/log.h>
 #include <compiler/node.h>
 
 namespace chainer_compiler {
@@ -72,7 +73,7 @@ std::vector<Order> ChenPolicy(const Graph& graph) {
             }
         }
         budget = budget / static_cast<int64_t>(std::sqrt(graph.nodes().size()));
-        std::cout << "Budget = " << budget / 1000000LL << " MB is used." << std::endl;
+        CLOG() << "Budget = " << budget / 1000000LL << " MB is used." << std::endl;
     }
 
     std::vector<Order> orders;
@@ -100,7 +101,7 @@ std::vector<Order> ChenPolicy(const Graph& graph) {
             sum += consumption;
         }
     }
-    for (auto s : splits) std::cout << "Split at " << s->ToString() << std::endl;
+    for (auto s : splits) CLOG() << "Split at " << s->ToString() << std::endl;
 
     // Determine nodes that should be retained after forward propagation
     std::map<Value*, size_t> generation;

--- a/compiler/computation_order/policy_gt.cc
+++ b/compiler/computation_order/policy_gt.cc
@@ -7,6 +7,7 @@
 
 #include <compiler/flags.h>
 #include <compiler/flops.h>
+#include <compiler/log.h>
 #include <runtime/meminfo.h>
 
 typedef std::vector<char> NodeSet;
@@ -381,7 +382,7 @@ int64_t AutomaticBudgetDetection() {
 
 std::vector<Order> GTPolicyTimeCentric(const Graph& graph) {
     const int64_t budget = (g_gt_budget ? (g_gt_budget * 1000000LL) : AutomaticBudgetDetection());
-    std::cerr << "GT budget (time centric)=" << budget << " bytes" << std::endl;
+    CLOG() << "GT budget (time centric)=" << budget << " bytes" << std::endl;
     SimpleGraph sg = GetSimpleFormGraph(graph);
 
     DiscretizeFlops(&sg);
@@ -400,12 +401,12 @@ std::vector<Order> GTPolicyMemoryCentric(const Graph& graph) {
 
     if (g_gt_budget) {
         const int64_t budget = g_gt_budget * 1000000LL;
-        std::cerr << "GT budget (memory centric) =" << budget << " bytes" << std::endl;
+        CLOG() << "GT budget (memory centric) =" << budget << " bytes" << std::endl;
         const std::vector<NodeSet> seq = ComputeDP(sg, lower_sets, budget, true);
         const std::vector<Order> orders = ComputeOrder(graph, sg, seq);
         return orders;
     } else {
-        std::cerr << "Determining budget size by binary search..." << std::endl;
+        CLOG() << "Determining budget size by binary search..." << std::endl;
 
         int64_t lo = 1;
         int64_t hi = 3 * std::accumulate(sg.memories.begin(), sg.memories.end(), 0LL);
@@ -421,7 +422,7 @@ std::vector<Order> GTPolicyMemoryCentric(const Graph& graph) {
             }
         }
 
-        std::cerr << "Budget size = " << hi << std::endl;
+        CLOG() << "Budget size = " << hi << std::endl;
         const std::vector<Order> orders = ComputeOrder(graph, sg, seq);
         return orders;
     }

--- a/compiler/gradient.cc
+++ b/compiler/gradient.cc
@@ -13,6 +13,7 @@
 #include <compiler/graph.h>
 #include <compiler/graph_builder.h>
 #include <compiler/node.h>
+#include <compiler/log.h>
 #include <compiler/tensor.h>
 #include <compiler/type.h>
 #include <compiler/value.h>
@@ -40,7 +41,7 @@ void ExposeParamGradsAsOutputs(Graph* graph, Graph* dest_graph, const std::set<V
         if (!input->type().dtype().IsFloat()) continue;
         if (!input->grad()) {
             if (input->users().size() == 1 && input->user(0)->op_type() == Node::kBatchNormalization) continue;
-            std::cerr << "No gradient for parameter: " << input->name() << std::endl;
+            CLOG() << "No gradient for parameter: " << input->name() << std::endl;
             ok = false;
             continue;
         }

--- a/compiler/gradient.cc
+++ b/compiler/gradient.cc
@@ -12,8 +12,8 @@
 #include <compiler/gradient_ops.h>
 #include <compiler/graph.h>
 #include <compiler/graph_builder.h>
-#include <compiler/node.h>
 #include <compiler/log.h>
+#include <compiler/node.h>
 #include <compiler/tensor.h>
 #include <compiler/type.h>
 #include <compiler/value.h>

--- a/compiler/gradient_with_order.cc
+++ b/compiler/gradient_with_order.cc
@@ -44,7 +44,7 @@ void ExposeParamGradsAsOutputs(Graph* graph, Graph* dest_graph, const std::set<V
         if (!input->type().dtype().IsFloat()) continue;
         if (!input->grad()) {
             if (input->users().size() == 1 && input->user(0)->op_type() == Node::kBatchNormalization) continue;
-            std::cerr << "No gradient for parameter: " << input->name() << std::endl;
+            CLOG() << "No gradient for parameter: " << input->name() << std::endl;
             // ok = false;
             continue;
         }


### PR DESCRIPTION
`std::cerr` is sometimes used in files under `compiler` directory, but this is a little verbose when chainer-compiler is used from python.
I suppress these just by replacing them with `CLOG`. I just did this only for gradient part. `std::cerr` is still used in other parts.