### PR TITLE
Add --disable_per_channel_quantize option

### DIFF
--- a/compiler/passes.cc
+++ b/compiler/passes.cc
@@ -118,6 +118,7 @@ void RunDefaultPasses(Graph* graph, bool gen_backprop, bool skip_scheduling) {
 
         if (g_quantize) {
             QuantizationOptions q_opts;
+            q_opts.per_channel = !g_disable_per_channel_quantize;
             Recursively([q_opts](Graph* graph) { Quantize(q_opts, graph); }, graph);
         }
 

--- a/scripts/generate_flags_code.py
+++ b/scripts/generate_flags_code.py
@@ -118,6 +118,10 @@ FLAGS = {
         'type': 'bool',
         'doc': 'Quantize ONNX model'
     },
+    'disable_per_channel_quantize': {
+        'type': 'bool',
+        'doc': 'Disables per channel quantization'
+    },
 
     'computation_order': {
         'type': 'std::string',


### PR DESCRIPTION
Usage:
```bash
~/dev/chainer-compiler$ ./build/tools/run_onnx --quantize ./data/mnist/
Initializing ChainerX...
Loading model...
Loading data...
Found 3 test cases
Constructing model...
Generate code...
Running for ./data/mnist//test_data_set_0
Verifying the result...
FAIL(value): Plus214_Output_0
Expected: array([[  975.67010498,  -618.72393799,  6574.56835938,   668.02893066,  -917.27093506, -1671.63586426, -1952.75988770,   -61.54987335,  -777.17663574, -1439.53161621]], shape=(1, 10), dtype=float32, device='native:0')
Actual: array([[  949.17773438,  -619.59661865,  6560.72607422,   638.2290039 ,  -918.04229736, -1663.55419922, -1975.22204590,   -44.86589432,  -775.35589600, -1421.17163086]], shape=(1, 10), dtype=float32, device='native:0')
Mismatch: 10 / 10 (100%)
Check `ok_cnt' == `test_case.outputs.size()' failed! in VerifyOutputs at ../tools/run_onnx_util.cc:268: (0 vs 1)
Aborted (core dumped)
~/dev/chainer-compiler$ ./build/tools/run_onnx --quantize --disable_per_channel_quantize ./data/mnist/
Initializing ChainerX...
Loading model...
Loading data...
Found 3 test cases
Constructing model...
Generate code...
Running for ./data/mnist//test_data_set_0
Verifying the result...
FAIL(value): Plus214_Output_0
Expected: array([[  975.67010498,  -618.72393799,  6574.56835938,   668.02893066,  -917.27093506, -1671.63586426, -1952.75988770,   -61.54987335,  -777.17663574, -1439.53161621]], shape=(1, 10), dtype=float32, device='native:0')
Actual: array([[  970.61535645,  -610.13140869,  6588.47851562,   625.06878662,  -911.78411865, -1684.60876465, -1983.74023438,   -29.74928093,  -788.45288086, -1440.35058594]], shape=(1, 10), dtype=float32, device='native:0')
Mismatch: 10 / 10 (100%)
Check `ok_cnt' == `test_case.outputs.size()' failed! in VerifyOutputs at ../tools/run_onnx_util.cc:268: (0 vs 1)
Aborted (core dumped)
```