### PR TITLE
Add wrapper option of snpe-dlc-info on SNPE backend

### DIFF
--- a/compiler/chxvm/emitter.cc
+++ b/compiler/chxvm/emitter.cc
@@ -447,16 +447,18 @@ private:
             CHECK_EQ(0, ret) << "Command failed: " << cmdline;
 
             if (g_dump_snpe_dlc_info) {
-                const std::string cmdline =
+                std::string cmdline =
                         StrCat("PYTHONPATH=",
                                snpe_dir,
                                "/lib/python",
                                " python2.7 ",
                                snpe_dir,
                                "/bin/x86_64-linux-clang/snpe-dlc-info"
-                               // TODO(take-cheeze): -s SAVE flag
                                " --input_dlc ",
                                snpe_model_file);
+                if (!g_snpe_dlc_info_out_prefix.empty()) {
+                    cmdline += StrCat(" -s ", g_snpe_dlc_info_out_prefix, node.chainer_fusion_group(), ".txt");
+                }
                 CLOG() << "Dumping snpe-dlc-info of: " << snpe_model_file << " with: " << cmdline << std::endl;
                 int ret = system(cmdline.c_str());
                 CHECK_EQ(0, ret) << "Command failed: " << cmdline;

--- a/compiler/chxvm/emitter.cc
+++ b/compiler/chxvm/emitter.cc
@@ -446,6 +446,22 @@ private:
             int ret = system(cmdline.c_str());
             CHECK_EQ(0, ret) << "Command failed: " << cmdline;
 
+            if (g_dump_snpe_dlc_info) {
+                const std::string cmdline =
+                        StrCat("PYTHONPATH=",
+                               snpe_dir,
+                               "/lib/python",
+                               " python2.7 ",
+                               snpe_dir,
+                               "/bin/x86_64-linux-clang/snpe-dlc-info"
+                               // TODO(take-cheeze): -s SAVE flag
+                               " --input_dlc ",
+                               snpe_model_file);
+                CLOG() << "Dumping snpe-dlc-info of: " << snpe_model_file << " with: " << cmdline << std::endl;
+                int ret = system(cmdline.c_str());
+                CHECK_EQ(0, ret) << "Command failed: " << cmdline;
+            }
+
             std::vector<int> inputs;
             std::vector<std::string> input_names;
             std::vector<ChxVMValue> outputs;

--- a/scripts/generate_flags_code.py
+++ b/scripts/generate_flags_code.py
@@ -75,6 +75,10 @@ FLAGS = {
         'type': 'bool',
         'doc': 'Use SNPE to execute operations.'
     },
+    'dump_snpe_dlc_info': {
+        'type': 'bool',
+        'doc': 'Dump result of snpe-dlc-info'
+    },
 
     'trace_level': {
         'type': 'int',

--- a/scripts/generate_flags_code.py
+++ b/scripts/generate_flags_code.py
@@ -79,6 +79,10 @@ FLAGS = {
         'type': 'bool',
         'doc': 'Dump result of snpe-dlc-info'
     },
+    'snpe_dlc_info_out_prefix': {
+        'type': 'std::string',
+        'doc': 'Output file of snpe-dlc-info'
+    },
 
     'trace_level': {
         'type': 'int',


### PR DESCRIPTION
Usage:
```bash
 ./build/tools/run_onnx --test ./out/chainercv_test_yolo_v2_tiny/ --use_snpe --dump_snpe_dlc_info
```

Usage(with snpe-dlc-info save option):
```bash
 ./build/tools/run_onnx --test ./out/chainercv_test_yolo_v2_tiny/ --use_snpe --dump_snpe_dlc_info --snpe_dlc_info_out_prefix snpe-dlc-info-
```