### PR TITLE
Make chainer-compiler symbols private in menoh library

### DIFF
--- a/menoh/CMakeLists.txt
+++ b/menoh/CMakeLists.txt
@@ -29,7 +29,7 @@ target_include_directories(menoh_chainer_compiler PRIVATE
   "${PYTHON_INCLUDE_DIRS}"
   "${CMAKE_CURRENT_BINARY_DIR}/.."
 )
-target_link_libraries(menoh_chainer_compiler
+set(MENOH_DEP_LIBS
   chainer_compiler_tools
   chainer_compiler_compiler
   chainer_compiler_configs
@@ -48,6 +48,7 @@ target_link_libraries(menoh_chainer_compiler
   absl::variant
   absl::optional
   )
+target_link_libraries(menoh_chainer_compiler PRIVATE ${MENOH_DEP_LIBS})
 
 if(OpenCV_FOUND)
     add_custom_command(
@@ -72,10 +73,10 @@ if(OpenCV_FOUND)
     target_link_libraries(menoh_example PRIVATE menoh_chainer_compiler "${OpenCV_LIBRARIES}")
 endif()
 
-add_executable(run_onnx_menoh run_onnx.cpp)
+add_executable(run_onnx_menoh run_onnx.cpp menoh_chainer_compiler.cpp)
 target_include_directories(run_onnx_menoh PRIVATE
   "${CHAINER_COMPILER_ROOT_DIR}/third_party/json/include"
   "${CHAINER_COMPILER_ROOT_DIR}"
   "${CMAKE_CURRENT_BINARY_DIR}/.."
 )
-target_link_libraries(run_onnx_menoh PRIVATE menoh_chainer_compiler)
+target_link_libraries(run_onnx_menoh PRIVATE ${MENOH_DEP_LIBS})

--- a/menoh/menoh.hpp
+++ b/menoh/menoh.hpp
@@ -360,7 +360,7 @@ namespace menoh {
         void* buffer_handle;
     };
 
-    int64_t variable_size_in_bytes(variable const& v) {
+    inline int64_t variable_size_in_bytes(variable const& v) {
         int64_t dtype_size;
         menoh_dtype_size(static_cast<menoh_dtype>(v.dtype), &dtype_size);
         return dtype_size * std::accumulate(v.dims.begin(), v.dims.end(), 1, std::multiplies<int64_t>());

--- a/menoh/run_onnx.cpp
+++ b/menoh/run_onnx.cpp
@@ -53,14 +53,7 @@
 #include <menoh/menoh.hpp>
 #include <menoh/menoh_chainer_compiler_util.hpp>
 
-chainerx::Dtype menoh_dtype_to_chx_dtype(menoh_dtype mdtype) {
-    return static_cast<chainerx::Dtype>(static_cast<int>(menoh_dtype_to_cc_dtype(mdtype)));
-}
-
-std::shared_ptr<void> allocate_buffer(chainerx::Shape const& shape, chainerx::Dtype dtype) {
-    auto bytesize = static_cast<size_t>(shape.GetTotalSize() * chainerx::GetItemSize(dtype));
-    return std::shared_ptr<uint8_t>{new uint8_t[bytesize], std::default_delete<uint8_t[]>()};
-}
+chainerx::Dtype menoh_dtype_to_chx_dtype(menoh_dtype mdtype);
 
 int main(int argc, char** argv) {
     std::cout << "run_onnx_menoh" << std::endl;


### PR DESCRIPTION
Rel: https://github.com/pfnet-research/chainer-compiler/pull/644
Needs to solve system protobuf version problem.