### PR TITLE
test: Enable subscript assignment test

### DIFF
--- a/chainer_compiler/elichika/onnx_converters.py
+++ b/chainer_compiler/elichika/onnx_converters.py
@@ -1241,8 +1241,8 @@ class ONNXGenerator:
                         onnx_node = oh.make_node(
                             'ChainerSequenceUpdate',
                             [value2onnx_parameter[node_.target].onnx_name,
-                                value2onnx_parameter[node_.revision].onnx_name,
-                                value2onnx_parameter[node_.indexes[0]].onnx_name],
+                                value2onnx_parameter[node_.indexes[0]].onnx_name,
+                                value2onnx_parameter[node_.revision].onnx_name],
                             [value2onnx_parameter[node.outputs[0]].onnx_name])
                         onnx_graph.nodes.append(onnx_node)
 

--- a/scripts/elichika_tests.py
+++ b/scripts/elichika_tests.py
@@ -112,7 +112,8 @@ TESTS = [
     Generator('syntax', 'Dict'),
     Generator('syntax', 'GetItem'),
     Generator('syntax', 'HasItem'),
-    Generator('syntax', 'Lambda')
+    Generator('syntax', 'Lambda'),
+    Generator('syntax', 'List')
 ]
 
 

--- a/testcases/elichika_tests/syntax/List.py
+++ b/testcases/elichika_tests/syntax/List.py
@@ -16,6 +16,13 @@ class ListSubscript(chainer.Chain):
         test_list[1] = 3
         return test_list
 
+class ListSubscript2(chainer.Chain):
+    def forward(self):
+        test_list = np.array([[0, 1], [1, 2], [2, 3]])
+        x = test_list[2]
+        test_list[1] = x
+        return test_list
+
 class ListAssignByValueRef(chainer.Chain):
     def forward(self):
         # shared reference
@@ -66,7 +73,8 @@ def main():
     testtools.generate_testcase(ListInConstructor(), [], subname='list_in_constructor')
 
     # TODO(rchouras): Fix following tests. First two are used very commonly.
-    # testtools.generate_testcase(ListSubscript, [], subname='list_subscript')
+    testtools.generate_testcase(ListSubscript, [], subname='list_subscript')
+    # testtools.generate_testcase(ListSubscript2, [], subname='list_subscript2')
     # testtools.generate_testcase(ListAssignByValueRef, [], subname='list_assign_by_value_ref')
     # testtools.generate_testcase(ListInfinitelyNested(), [], subname='list_nested')
 


### PR DESCRIPTION
Enabling test that uses `ChainerSequenceUpdate` for subscript assignment. Adding a test for `ChainerSetItem` which isn't working properly (Could be an issue in parameter order).