### PR TITLE
Add inference rules for numpy.array

### DIFF
--- a/chainer_compiler/elichika/typing/types.py
+++ b/chainer_compiler/elichika/typing/types.py
@@ -597,6 +597,7 @@ def copy_ty(ty):
 def tyobj2dtype(ty):
     if isinstance(ty, TyNum):
         return np.dtype(str(NumKind(ty.kind)))
+    assert False
 
 
 # ==============================================================================


### PR DESCRIPTION
This will allow us to delete `make_infer` as well.