### PR TITLE
Clean up test directories before export_testcase

### DIFF
--- a/scripts/gen_backprop_tests_oc.py
+++ b/scripts/gen_backprop_tests_oc.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+import shutil
+
 import chainer
 import numpy as np
 import onnx_chainer
@@ -28,6 +30,7 @@ def create_backprop_test(test_name, fn, dtype=np.float32, **kwargs):
     model = AnyModel(fn, params)
 
     chainer.disable_experimental_feature_warning = True
+    shutil.rmtree(test_dir, ignore_errors=True)
     onnx_chainer.export_testcase(model,
                                  (),
                                  test_dir,

--- a/scripts/gen_chainercv_model_tests.py
+++ b/scripts/gen_chainercv_model_tests.py
@@ -1,6 +1,7 @@
 """Tests for ChainerCV models."""
 
 import os
+import shutil
 
 import chainer
 import chainer.functions as F
@@ -24,8 +25,10 @@ def chainercv_model_test(model):
     def fn(test_name):
         np.random.seed(42)
         x = np.random.rand(1, 3, 224, 224).astype(np.float32)
+        test_dir = os.path.join('out', test_name)
+        shutil.rmtree(test_dir, ignore_errors=True)
         onnx_chainer.export_testcase(model, [x],
-                                     os.path.join('out', test_name),
+                                     test_dir,
                                      opset_version=9)
 
     return fn

--- a/scripts/gen_large_tests_oc.py
+++ b/scripts/gen_large_tests_oc.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+import shutil
+
 import chainer
 import numpy as np
 import onnx_chainer
@@ -20,6 +22,7 @@ def create_test(test_name, get_fun, dtype):
     test_dir = 'out/%s' % test_name
 
     chainer.disable_experimental_feature_warning = True
+    shutil.rmtree(test_dir, ignore_errors=True)
     onnx_chainer.export_testcase(model,
                                  inputs,
                                  test_dir,

--- a/scripts/gen_mnist_mlp.py
+++ b/scripts/gen_mnist_mlp.py
@@ -3,6 +3,7 @@
 """An MNIST trainer which is exportable by ONNX-chainer."""
 
 import argparse
+import shutil
 
 import numpy as np
 
@@ -165,6 +166,7 @@ def main_impl(args):
     onehot = chainer.Variable(onehot, name='onehot')
 
     chainer.disable_experimental_feature_warning = True
+    shutil.rmtree(out_dir, ignore_errors=True)
     onnx_chainer.export_testcase(model,
                                  (x, onehot),
                                  out_dir,

--- a/scripts/gen_resnet50.py
+++ b/scripts/gen_resnet50.py
@@ -10,6 +10,7 @@ $ PYTHONPATH=third_party/onnx-chainer python3 scripts/gen_resnet50.py
 import argparse
 import os
 import random
+import shutil
 import sys
 
 import numpy as np
@@ -222,6 +223,7 @@ def main_impl(args, model_cls):
     onehot = chainer.Variable(onehot, name='onehot')
 
     chainer.disable_experimental_feature_warning = True
+    shutil.rmtree(out_dir, ignore_errors=True)
     onnx_chainer.export_testcase(model,
                                  (x, onehot),
                                  out_dir,


### PR DESCRIPTION
This makes test generation more robust when the number of
inputs/outputs/gradients are changed.