### PR TITLE
run_onnx_menoh should depend on menoh_chainer_compiler_cc_inc

### DIFF
--- a/menoh/CMakeLists.txt
+++ b/menoh/CMakeLists.txt
@@ -62,6 +62,7 @@ if(OpenCV_FOUND)
 endif()
 
 add_executable(run_onnx_menoh run_onnx.cpp menoh_chainer_compiler.cpp)
+add_dependencies(run_onnx_menoh menoh_chainer_compiler_cc_inc)
 target_include_directories(run_onnx_menoh PRIVATE
   "${CHAINER_COMPILER_ROOT_DIR}/third_party/json/include"
   "${CHAINER_COMPILER_ROOT_DIR}"


### PR DESCRIPTION
This fix the following compilation error.
```
Scanning dependencies of target run_onnx_menoh
[ 97%] Building CXX object menoh/CMakeFiles/run_onnx_menoh.dir/run_onnx.cpp.o
chainer-compiler/menoh/run_onnx.cpp:160:10: fatal error: 'menoh/args_json.inc' file not found
         ^~~~~~~~~~~~~~~~~~~~~
1 error generated.
```