### PR TITLE
fix ambiguity of conversion from 0L to chainerx::Scalar.

### DIFF
--- a/runtime/ops/indexing.cc
+++ b/runtime/ops/indexing.cc
@@ -443,7 +443,7 @@ std::tuple<chainerx::Array, chainerx::Array> TopKOp::RunImpl(ChxVMState* st, con
     chainerx::Shape out_shape = in_shape;
     out_shape[axis] = k;
     if (k == 0) {
-        return std::make_tuple(chainerx::Full(out_shape, 0.f, x.device()), chainerx::Full(out_shape, 0L, x.device()));
+        return std::make_tuple(chainerx::Full(out_shape, 0.f, x.device()), chainerx::Full(out_shape, static_cast<int64_t>(0L), x.device()));
     }
 
     int64_t rows = 1;


### PR DESCRIPTION
Clang says it is ambiguous and candidate constructors are: `Scalar(bool v)`, `Scalar(int8_t v)`, `Scalar(int16_t v)`, `Scalar(int32_t v)`, `Scalar(int64_t v)`, `Scalar(uint8_t v)`, `Scalar(uint16_t v)`, `Scalar(uint32_t v)`, `Scalar(float v)` and `Scalar(double v)`.

I'm using `Apple LLVM version 10.0.0 (clang-1000.11.45.5)` on macOS Mojave.