### PR TITLE
fix undefined symbol errors on macOS

### DIFF
--- a/chainer_compiler_cc/CMakeLists.txt
+++ b/chainer_compiler_cc/CMakeLists.txt
@@ -35,3 +35,9 @@ set_target_properties(_chainer_compiler_core.so
     PREFIX "${PYTHON_MODULE_PREFIX}"
     SUFFIX "${PYTHON_MODULE_SUFFIX}")
 set_hidden_(_chainer_compiler_core.so)
+
+if(APPLE)
+    set_property(
+        TARGET _chainer_compiler_core.so APPEND_STRING PROPERTY
+            LINK_FLAGS "-undefined dynamic_lookup")
+endif()

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -108,6 +108,11 @@ if (${CHAINER_COMPILER_ENABLE_PYTHON})
     PROPERTIES
     PREFIX "${PYTHON_MODULE_PREFIX}"
     SUFFIX "${PYTHON_MODULE_SUFFIX}")
+  if(APPLE)
+    set_property(
+      TARGET run_onnx_core.so APPEND_STRING PROPERTY
+          LINK_FLAGS "-undefined dynamic_lookup")
+  endif()
 
   if(${CHAINER_COMPILER_ENABLE_OPENCV})
     add_library(train_imagenet_core.so MODULE train_imagenet_core.cc)
@@ -128,6 +133,11 @@ if (${CHAINER_COMPILER_ENABLE_PYTHON})
       PROPERTIES
       PREFIX "${PYTHON_MODULE_PREFIX}"
       SUFFIX "${PYTHON_MODULE_SUFFIX}")
+    if(APPLE)
+      set_property(
+        TARGET train_imagenet_core.so APPEND_STRING PROPERTY
+            LINK_FLAGS "-undefined dynamic_lookup")
+    endif()
   endif()
 
 endif()


### PR DESCRIPTION
This fixes errors like following:
```
[100%] Linking CXX shared module run_onnx_core.so
Undefined symbols for architecture x86_64:
  "_PyBaseObject_Type", referenced from:
      pybind11::detail::make_object_base_type(_typeobject*) in run_onnx_core.cc.o
```

I'm using `Apple LLVM version 10.0.0 (clang-1000.11.45.5)` on macOS Mojave.