### PR TITLE
Deprecate use of exception for inference of function calls

### DIFF
--- a/chainer_compiler/elichika/typing/std/list_functions.py
+++ b/chainer_compiler/elichika/typing/std/list_functions.py
@@ -1,0 +1,17 @@
+from   chainer_compiler.elichika.typing.types  import *
+
+def ty_append(ty_args, ty_kwargs):
+    ty_list, ty_elem = ty_args
+    unify(ty_list.get(), ty_elem)
+    return TyNone()
+
+
+def ty_reverse(ty_args, ty_kwargs):
+    ty_list, = ty_args
+    return TyNone()
+
+
+list_func_ty = {
+        list.append  : ty_append,
+        list.reverse : ty_reverse,
+        }

--- a/chainer_compiler/elichika/typing/type_inference.py
+++ b/chainer_compiler/elichika/typing/type_inference.py
@@ -702,7 +702,6 @@ class InferenceEngine():
                     return getattr(torch.Tensor, node.attr), ty_obj
 
             if isinstance(ty_obj, TyUserDefinedClass):
-                # x: value of existing instance
                 return getattr(ty_obj.instance, node.attr), None
 
         if isinstance(node, gast.Name):

--- a/chainer_compiler/elichika/typing/type_inference.py
+++ b/chainer_compiler/elichika/typing/type_inference.py
@@ -704,11 +704,9 @@ class InferenceEngine():
             ty_fun = self.infer_expr(node.func, is_callee=True)
             unify(ty_fun, TyArrow(ty_args, ty_ret))
         except self.ArgumentRequired as e:
-            # Attribute
-            if isinstance(e.func, tuple):
-                (func, ty_obj) = e.func
-                e.func = func
-                ty_args_ = [ty_obj] + ty_args
+            if e.ty_obj is not None:
+                # Attribute
+                ty_args_ = [e.ty_obj] + ty_args
             else:
                 ty_args_ = ty_args
 
@@ -750,10 +748,10 @@ class InferenceEngine():
                 return TyInt()
             if ty_obj.is_ndarray() and is_callee:
                 func = getattr(np.ndarray, node.attr)
-                raise self.ArgumentRequired((func, ty_obj))
+                raise self.ArgumentRequired(func=func, ty_obj=ty_obj)
             if ty_obj.is_torch_tensor() and is_callee:
                 func = getattr(torch.Tensor, node.attr)
-                raise self.ArgumentRequired((func, ty_obj))
+                raise self.ArgumentRequired(func=func, ty_obj=ty_obj)
             assert False
 
         if isinstance(ty_obj, TyUserDefinedClass):

--- a/chainer_compiler/elichika/typing/type_inference.py
+++ b/chainer_compiler/elichika/typing/type_inference.py
@@ -831,13 +831,12 @@ class InferenceEngine():
         # Name(identifier id, expr_context ctx, expr? annotation)
         if node.id in self.tyenv.keys():
             ty = self.tyenv[node.id]
-            if is_callee and isinstance(ty, TyUserDefinedClass) and \
-                    callable(ty.instance):
+            if is_callee and isinstance(ty, TyUserDefinedClass):
                 raise self.ArgumentRequired(func=ty.instance)
             return self.tyenv[node.id]
         if node.id in __builtins__.keys():
             value = __builtins__[node.id]
-            if callable(value) and is_callee:
+            if is_callee:
                 raise self.ArgumentRequired(func=value)
             return type_of_value(value)
         if hasattr(self.module, node.id):

--- a/chainer_compiler/elichika/typing/type_inference.py
+++ b/chainer_compiler/elichika/typing/type_inference.py
@@ -705,7 +705,6 @@ class InferenceEngine():
             unify(ty_fun, TyArrow(ty_args, ty_ret))
         except self.ArgumentRequired as e:
             if e.ty_obj is not None:
-                # Attribute
                 ty_args_ = [e.ty_obj] + ty_args
             else:
                 ty_args_ = ty_args
@@ -758,18 +757,13 @@ class InferenceEngine():
             # x: value of existing instance
             x = getattr(ty_obj.instance, node.attr)
 
-            if callable(x) and x in __builtins__.keys():
-                raise self.ArgumentRequired(func=x)
-
-            if (ty_obj.instance, node.attr) in self.attribute_tyenv.keys():
-                ty_node = self.attribute_tyenv[(ty_obj.instance, node.attr)]
-            else:
-                ty_node = type_of_value(x)
-
             if is_callee:
                 raise self.ArgumentRequired(func=x)
 
-            return ty_node
+            if (ty_obj.instance, node.attr) in self.attribute_tyenv.keys():
+                return self.attribute_tyenv[(ty_obj.instance, node.attr)]
+
+            return type_of_value(x)
 
         if isinstance(ty_obj, TyNone):
             return TyVar()

--- a/chainer_compiler/elichika/typing/type_inference.py
+++ b/chainer_compiler/elichika/typing/type_inference.py
@@ -217,26 +217,6 @@ class InferenceEngine():
         return t
 
 
-    def evaluate(self, node):
-        if isinstance(node, gast.Attribute):
-            v_value = self.evaluate(node.value)
-            if v_value is None:
-                return None
-            attr = getattr(v_value, node.attr)
-            return attr
-
-        if isinstance(node, gast.Constant):
-            return node.value
-
-        if isinstance(node, gast.Name) and hasattr(self.module, node.id):
-            return getattr(self.module, node.id)
-
-        if isinstance(node, gast.Name) and node.id in self.tyenv.keys() and \
-                isinstance(self.tyenv[node.id], TyUserDefinedClass):
-            # ex. value of 'self'
-            return self.tyenv[node.id].instance
-
-
     def infer(self, node):
         self.infer_mod(node)
         return self.nodetype


### PR DESCRIPTION
This PR removes the use of exception `ArgumentRequired` when the inference engine fails to retrieve the type signature (types that is not dependent on the type of argument) of functions, as it fails to do so in most cases. This frequent use of exception has made it difficult for us to read the error message when the inference failed.