### PR TITLE
Refactor type inference

### DIFF
--- a/chainer_compiler/elichika/typing/ext/chainer_functions.py
+++ b/chainer_compiler/elichika/typing/ext/chainer_functions.py
@@ -8,10 +8,13 @@ import math
 from   chainer.utils.conv import get_conv_outsize
 from   chainer.utils import type_check
 
+from   chainer_compiler.elichika.typing.ext.common import *
 from   chainer_compiler.elichika.typing.ext.utils  import *
 from   chainer_compiler.elichika.typing.shape_elem import *
 from   chainer_compiler.elichika.typing.types      import *
 from   chainer_compiler.elichika.typing.utils      import all_same
+
+__all__ = [ 'chainer_attr_ty', 'chainer_func_ty', 'chainer_callable_ty' ]
 
 
 class ty_ChainerVariable():
@@ -750,6 +753,12 @@ class ty_ChainerNStepBiLSTM():
         ys_type = TyList([TyChainerVariable(xs_dtypes[0], shape=s) for s in ys_shapes])
 
         return TyTuple([hy_type, cy_type, ys_type])
+
+
+chainer_attr_ty = {
+        'shape'  : ty_Shape,
+        'size'   : ty_Size,
+        }
 
 
 chainer_func_ty = {

--- a/chainer_compiler/elichika/typing/ext/common.py
+++ b/chainer_compiler/elichika/typing/ext/common.py
@@ -3,8 +3,19 @@ from   chainer_compiler.elichika.typing.types      import *
 from   chainer_compiler.elichika.typing.shape_elem import *
 
 __all__ = [ 'ty_MakeTensor'
+          , 'ty_Shape'
+          , 'ty_Size'
           , 'ty_TensorArith'
           ]
+
+
+def ty_Shape(ty_obj):
+    return TyTuple([TyInt(e.value) for e in ty_obj.shape])
+
+
+def ty_Size(ty_obj):
+    size = size_of_shape(ty_obj.shape)
+    return TyInt(size.value)
 
 
 class ty_MakeTensor():

--- a/chainer_compiler/elichika/typing/ext/numpy_functions.py
+++ b/chainer_compiler/elichika/typing/ext/numpy_functions.py
@@ -5,6 +5,8 @@ from   chainer_compiler.elichika.typing.ext.common import *
 from   chainer_compiler.elichika.typing.ext.utils  import *
 from   chainer_compiler.elichika.typing.types      import *
 
+__all__ = [ 'numpy_attr_ty', 'numpy_func_ty' ]
+
 
 class ty_NumpyAstype():
     def __call__(self, ty_args, ty_kwargs):
@@ -63,6 +65,11 @@ class ty_NumpyFull():
             shape = (shape,)
         return TyNdarray(dtype, shape=shape)
 
+
+numpy_attr_ty = {
+        'shape'  : ty_Shape,
+        'size'   : ty_Size,
+        }
 
 numpy_func_ty = {
         np.ndarray.astype : ty_NumpyAstype(),

--- a/chainer_compiler/elichika/typing/ext/pytorch/nn.py
+++ b/chainer_compiler/elichika/typing/ext/pytorch/nn.py
@@ -15,6 +15,7 @@ __all__ = [ 'ty_TorchConv'
           , 'ty_TorchInstanceNorm'
           , 'ty_TorchLSTMCell'
           , 'ty_TorchLinear'
+          , 'ty_TorchEmbed'
           , 'ty_TorchNNCrossEntropyLoss'
           , 'ty_TorchPixelShuffle'
           , 'ty_TorchInterpolate'
@@ -229,6 +230,25 @@ class ty_TorchLinear():
 # Dropout
 
 # Sparse
+
+class ty_TorchEmbed():
+    def nn(self, obj, ty_args, ty_kwargs):
+        x_type, = ty_args
+        assert x_type.dtype == np.int64, "dtype of input must be int64"
+        embedding_dim = obj.embedding_dim
+        shape = x_type.shape + (embedding_dim,)
+        # TODO(momohatt): Use global dtype
+        return TyTorchTensor(np.float32, shape=shape)
+
+    def __call__(self, ty_args, ty_kwargs):
+        x_type, weight_type = ty_args
+        assert x_type.dtype == np.int64, "dtype of input must be int64"
+        assert weight_type.dtype.kind == 'f'
+        assert weight_type.ndim == 2
+        embedding_dim = weight_type.shape[1]
+        shape = x_type.shape + (embedding_dim,)
+        return TyTorchTensor(weight_type.dtype, shape=shape)
+
 
 # Distance functions
 

--- a/chainer_compiler/elichika/typing/ext/pytorch/tensor.py
+++ b/chainer_compiler/elichika/typing/ext/pytorch/tensor.py
@@ -14,6 +14,7 @@ __all__ = [ 'ty_TorchIdentical'
           , 'ty_TorchCat'
           , 'ty_TorchChunk'
           , 'ty_TorchReshape'
+          , 'ty_TorchSize'
           , 'ty_TorchSplit'
           , 'ty_TorchSqueeze'
           , 'ty_TorchStack'
@@ -144,6 +145,12 @@ class ty_TorchReshape():
     def infer_return(self, x_type):
         ret_shape = calculate_reshape(x_type.shape, self.shape)
         return TyTorchTensor(x_type.dtype, shape=ret_shape)
+
+
+class ty_TorchSize():
+    def __call__(self, ty_args, ty_kwargs):
+        x_type, = ty_args
+        return TyTuple([TyInt(e.value) for e in x_type.shape])
 
 
 class ty_TorchSplit():

--- a/chainer_compiler/elichika/typing/ext/pytorch_functions.py
+++ b/chainer_compiler/elichika/typing/ext/pytorch_functions.py
@@ -6,10 +6,16 @@ from   chainer.utils import type_check
 
 from   chainer_compiler.elichika.typing.ext.utils          import *
 from   chainer_compiler.elichika.typing.types              import *
+from   chainer_compiler.elichika.typing.ext.common         import *
 from   chainer_compiler.elichika.typing.ext.pytorch.nn     import *
 from   chainer_compiler.elichika.typing.ext.pytorch.tensor import *
 
-__all__ = [ 'pytorch_func_ty', 'pytorch_callable_ty' ]
+__all__ = [ 'pytorch_attr_ty', 'pytorch_func_ty', 'pytorch_callable_ty' ]
+
+
+pytorch_attr_ty = {
+        'shape' : ty_Shape,
+        }
 
 
 pytorch_func_ty = {

--- a/chainer_compiler/elichika/typing/ext/pytorch_functions.py
+++ b/chainer_compiler/elichika/typing/ext/pytorch_functions.py
@@ -67,6 +67,9 @@ pytorch_func_ty = {
         F.tanh        : ty_TorchIdentical(),
         F.sigmoid     : ty_TorchIdentical(),
 
+        # https://pytorch.org/docs/stable/nn.functional.html#sparse-functions
+        F.embedding   : ty_TorchEmbed(),
+
         # https://pytorch.org/docs/stable/nn.functional.html#vision-functions
         F.interpolate : ty_TorchInterpolate(),
 
@@ -79,9 +82,12 @@ pytorch_func_ty = {
 
         torch.Tensor.chunk     : ty_TorchChunk(),
         torch.Tensor.repeat    : ty_TorchRepeat(),
+        torch.Tensor.size      : ty_TorchSize(),
         torch.Tensor.squeeze   : ty_TorchSqueeze(),
         torch.Tensor.unsqueeze : ty_TorchUnsqueeze(),
         torch.Tensor.view      : ty_TorchView(),
+
+        torch.Tensor.detach    : ty_TorchIdentical(),
         }
 
 
@@ -143,6 +149,9 @@ pytorch_callable_ty = {
         nn.Dropout2d        : ty_TorchIdentical(ndim_min=1).nn,
         nn.Dropout3d        : ty_TorchIdentical(ndim_min=1).nn,
         nn.AlphaDropout     : ty_TorchIdentical().nn,
+
+        # https://pytorch.org/docs/stable/nn.html#sparse-layers
+        nn.Embedding        : ty_TorchEmbed().nn,
 
         # https://pytorch.org/docs/stable/nn.html#loss-functions
         nn.CrossEntropyLoss : ty_TorchNNCrossEntropyLoss().nn,

--- a/chainer_compiler/elichika/typing/type_inference.py
+++ b/chainer_compiler/elichika/typing/type_inference.py
@@ -72,10 +72,10 @@ def lazy_initializer(node):
 
 
 def handle_inference_error(exception, func, node):
-    if hasattr(func, '__class__'):
-        name = func.__class__.__name__
-    elif hasattr(func, '__name__'):
+    if hasattr(func, '__name__'):
         name = func.__name__
+    elif hasattr(func, '__class__'):
+        name = func.__class__.__name__
     else:
         name = str(func)
     utils.print_warning(str(exception))

--- a/chainer_compiler/elichika/typing/type_inference.py
+++ b/chainer_compiler/elichika/typing/type_inference.py
@@ -766,7 +766,7 @@ class InferenceEngine():
                 if ty_obj.shape is None:
                     return TyTuple(TyInt())
                 return type_of_value(ty_obj.shape)
-            if node.attr == 'size':
+            if ty_obj.is_ndarray() and node.attr == 'size':
                 return TyInt()
             if ty_obj.is_ndarray() and is_callee:
                 func = getattr(np.ndarray, node.attr)

--- a/chainer_compiler/elichika/typing/type_inference.py
+++ b/chainer_compiler/elichika/typing/type_inference.py
@@ -539,7 +539,7 @@ class InferenceEngine():
 
     def infer_For(self, node):
         # For(expr target, expr iter, stmt* body, stmt* orelse)
-        assert type(node.target) in [gast.Name, gast.Tuple]
+        assert isinstance(node.target, (gast.Name, gast.Tuple))
 
         ty_iteration = self.infer_expr(node.iter)
         ty_i = self.infer_expr(node.target)

--- a/chainer_compiler/elichika/typing/types.py
+++ b/chainer_compiler/elichika/typing/types.py
@@ -274,12 +274,9 @@ class TensorKind(Enum):
 
 
 class TyDType(TyObj):
-    def __init__(self, t=None):
+    def __init__(self, t):
         super().__init__()
-        if t is None:
-            self.t = None
-        else:
-            self.t = np.dtype(t)
+        self.t = np.dtype(t)
     def __str__(self):
         return "dtype({})".format(str(self.t))
     def __eq__(self, other):
@@ -697,7 +694,7 @@ def unify(ty1, ty2, inspect_shape=True):
             return
 
     if isinstance(ty1, TyDType) and isinstance(ty2, TyDType):
-        utils.set_attr_if_None(ty1.dtype, ty2.dtype, 't')
+        assert ty1.t == ty2.t
         return
 
     if isinstance(ty1, TyUserDefinedClass) and \

--- a/testcases/pytorch/ResNet.py
+++ b/testcases/pytorch/ResNet.py
@@ -190,6 +190,7 @@ class ResNet(nn.Module):
         x = self.layer4(x)
 
         x = self.avgpool(x)
+        # EDIT(momohatt): Add 'start_dim='
         x = torch.flatten(x, start_dim=1)
         x = self.fc(x)
 


### PR DESCRIPTION
This PR adds minor refinements to the type inference engine, including:
* Adding type signature for `torch.nn.Embedding` (which I implemented in attempt to typecheck [SNLI](https://github.com/pytorch/examples/blob/master/snli/model.py) example but gave up in the middle because the program creates user-defined object in `forward`)
* Add a function to compute the type of `x.shape` and `x.size` (where `x` is a tensor), which used to be embedded in the inference engine