### PR TITLE
Fix unification of shapes

### DIFF
--- a/chainer_compiler/elichika/typing/ext/pytorch/tensor.py
+++ b/chainer_compiler/elichika/typing/ext/pytorch/tensor.py
@@ -15,6 +15,7 @@ __all__ = [ 'ty_TorchIsTensor'
           , 'ty_TorchFromNumpy'
           , 'ty_TorchCat'
           , 'ty_TorchChunk'
+          , 'ty_TorchExpand'
           , 'ty_TorchNumpy'
           , 'ty_TorchReshape'
           , 'ty_TorchSize'
@@ -154,6 +155,14 @@ class ty_TorchChunk():
             for _ in range(chunks)])
 
 
+class ty_TorchExpand():
+    def __call__(self, ty_args, ty_kwargs):
+        x_type = ty_args[0]
+        assert all([isinstance(ty, TyNum) for ty in ty_args[1:]])
+        shape = [ty.value for ty in ty_args[1:]]
+        return TyTorchTensor(x_type.dtype, shape=shape)
+
+
 class ty_TorchNumpy():
     def __call__(self, ty_args, ty_kwargs):
         x_type, = ty_args
@@ -183,7 +192,7 @@ class ty_TorchSize():
             assert index_type.is_int()
             if index_type.value is None:
                 return TyInt()
-            return TyInt(x_type.shape[index_type.value])
+            return TyInt(x_type.shape[index_type.value].value)
 
         x_type, = ty_args
         return TyTuple([TyInt(e.value) for e in x_type.shape])

--- a/chainer_compiler/elichika/typing/ext/pytorch_functions.py
+++ b/chainer_compiler/elichika/typing/ext/pytorch_functions.py
@@ -94,6 +94,7 @@ pytorch_func_ty = {
         torch.Tensor.chunk     : ty_TorchChunk(),
         torch.Tensor.contiguous : ty_TorchIdentical(is_float_only=False),
         torch.Tensor.cpu       : ty_TorchIdentical(is_float_only=False),
+        torch.Tensor.expand    : ty_TorchExpand(),
         torch.Tensor.numpy     : ty_TorchNumpy(),
         torch.Tensor.repeat    : ty_TorchRepeat(),
         torch.Tensor.size      : ty_TorchSize(),

--- a/chainer_compiler/elichika/typing/type_inference.py
+++ b/chainer_compiler/elichika/typing/type_inference.py
@@ -259,12 +259,10 @@ class InferenceEngine():
                             type_of_value(val)
 
         # apply type hints
+        subst = match_types([self.tyenv[n] for n in type_hints.keys()],
+            type_hints.values())
         for n, t in type_hints.items():
-            # TODO(momohatt): use term-match instead of unify?
-            unify(self.tyenv[n], t)
-            if isinstance(t, TyTensor):
-                for i in range(self.tyenv[n].ndim):
-                    self.tyenv[n].shape[i].expr = t.shape[i].expr
+            self.tyenv[n] = apply_subst(subst, type_hints[n])
 
         self.infer_stmt(node)
 

--- a/tests/elichika_typing/Shape_test.py
+++ b/tests/elichika_typing/Shape_test.py
@@ -5,6 +5,8 @@ import chainer.functions as F
 import chainer.links as L
 import numpy as np
 
+import torch
+
 from   chainer_compiler.elichika.testtools import generate_id2type_from_forward
 from   chainer_compiler.elichika.typing import types
 
@@ -16,7 +18,7 @@ class TestShape(unittest.TestCase):
                     x = x.expand(4, x.size(1) + 1)
                 return x
 
-        model, forward_args = Test(), (torch.Tensor(4, 1, dtype=torch.float),)
+        model, forward_args = Test(), (torch.ones(4, 1, dtype=torch.float),)
         id2type = generate_id2type_from_forward(model, forward_args)
 
         self.assertEqual(str(id2type[1]), "class Test -> torch.Tensor(float32, (4, None)) -> torch.Tensor(float32, (4, None))")	# FunctionDef forward (line 1)

--- a/tests/elichika_typing/Shape_test.py
+++ b/tests/elichika_typing/Shape_test.py
@@ -9,6 +9,39 @@ from   chainer_compiler.elichika.testtools import generate_id2type_from_forward
 from   chainer_compiler.elichika.typing import types
 
 class TestShape(unittest.TestCase):
+    def test_shape_unify(self):
+        class Test():
+            def forward(self, x):
+                for i in range(5):
+                    x = x.expand(4, x.size(1) + 1)
+                return x
+
+        model, forward_args = Test(), (torch.Tensor(4, 1, dtype=torch.float),)
+        id2type = generate_id2type_from_forward(model, forward_args)
+
+        self.assertEqual(str(id2type[1]), "class Test -> torch.Tensor(float32, (4, None)) -> torch.Tensor(float32, (4, None))")	# FunctionDef forward (line 1)
+        self.assertEqual(str(id2type[7]), "NoneType")	# For
+        self.assertEqual(str(id2type[8]), "int")	# Name i (line 2)
+        self.assertEqual(str(id2type[10]), "int list")	# Call range(5) (line 2)
+        self.assertEqual(str(id2type[11]), "int -> int list")	# Name range (line 2)
+        self.assertEqual(str(id2type[13]), "int")	# Constant 5 (line 2)
+        self.assertEqual(str(id2type[14]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[15]), "torch.Tensor(float32, (4, None))")	# Name x (line 3)
+        self.assertEqual(str(id2type[17]), "torch.Tensor(float32, (4, None))")	# Call x.expand(4, x.size(1) + 1) (line 3)
+        self.assertEqual(str(id2type[18]), "int -> int -> torch.Tensor(float32, (4, None))")	# Attribute x.expand (line 3)
+        self.assertEqual(str(id2type[19]), "torch.Tensor(float32, (4, None))")	# Name x (line 3)
+        self.assertEqual(str(id2type[22]), "int")	# Constant 4 (line 3)
+        self.assertEqual(str(id2type[23]), "int")	# BinOp x.size(1) + 1 (line 3)
+        self.assertEqual(str(id2type[24]), "int")	# Call x.size(1) (line 3)
+        self.assertEqual(str(id2type[25]), "int -> int")	# Attribute x.size (line 3)
+        self.assertEqual(str(id2type[26]), "torch.Tensor(float32, (4, None))")	# Name x (line 3)
+        self.assertEqual(str(id2type[29]), "int")	# Constant 1 (line 3)
+        self.assertEqual(str(id2type[30]), "int -> int -> int")	# Add
+        self.assertEqual(str(id2type[31]), "int")	# Constant 1 (line 3)
+        self.assertEqual(str(id2type[32]), "torch.Tensor(float32, (4, None))")	# Return
+        self.assertEqual(str(id2type[33]), "torch.Tensor(float32, (4, None))")	# Name x (line 4)
+
+
     def test_type_hints(self):
         class Test():
             def forward(self, x: types.TyNdarray(np.float32, ('a', 'b'))):


### PR DESCRIPTION
This PR fixes the unification of shapes. Originally,
```
x = ShapeElem(1)
y = ShapeElem(None)
unify_shape((x,), (y,))
```
would have changed y into `(ShapeElem(1),)`.  However, this will result in the following inference.
```
x = torch.Tensor(4, 1, dtype=torch.float)
for i in range(5):
    x = x.expand(4, x.size(1) + 1)
# x : torch.Tensor(float32, (4, 1)) <-- shape should be (4, None)
```
This PR a) fixes this behavior, and b) adds implementation for applying shape annotation for tensors, which will be broken by a).