### PR TITLE
Add tests for type inference engine for pytorch

### DIFF
--- a/chainer_compiler/elichika/typing/ext/pytorch/utils.py
+++ b/chainer_compiler/elichika/typing/ext/pytorch/utils.py
@@ -6,6 +6,6 @@ __all__ = [ 'check_dtype'
 def check_dtype(module, dtype):
     for m in module.parameters():
         assert torch_dtype_to_np_dtype(m.dtype) == dtype, \
-                "dtype mismatch in {}".format(module.__name__)
+                "dtype mismatch in {}".format(type(module).__name__)
         # Checking the first param is enough
         return

--- a/chainer_compiler/elichika/typing/ext/pytorch_functions.py
+++ b/chainer_compiler/elichika/typing/ext/pytorch_functions.py
@@ -78,6 +78,12 @@ pytorch_func_ty = {
         F.tanh        : ty_TorchIdentical(),
         F.sigmoid     : ty_TorchIdentical(),
 
+        # https://pytorch.org/docs/stable/nn.functional.html#dropout-functions
+        F.dropout         : ty_TorchIdentical(),
+        F.dropout2d       : ty_TorchIdentical(ndim_min=1),
+        F.dropout3d       : ty_TorchIdentical(ndim_min=1),
+        F.alpha_dropout   : ty_TorchIdentical(),
+
         # https://pytorch.org/docs/stable/nn.functional.html#sparse-functions
         F.embedding   : ty_TorchEmbed(),
 

--- a/testcases/pytorch/examples/dcgan.py
+++ b/testcases/pytorch/examples/dcgan.py
@@ -1,0 +1,89 @@
+# https://github.com/pytorch/examples/blob/master/dcgan/main.py
+
+import torch
+import torch.nn as nn
+
+
+bs, nz, ngf, nc, ndf = 5, 6, 9, 3, 10
+
+class Generator(nn.Module):
+    def __init__(self, ngpu):
+        super(Generator, self).__init__()
+        self.ngpu = ngpu
+        self.main = nn.Sequential(
+            # input is Z, going into a convolution
+            nn.ConvTranspose2d(     nz, ngf * 8, 4, 1, 0, bias=False),
+            nn.BatchNorm2d(ngf * 8),
+            nn.ReLU(True),
+            # state size. (ngf*8) x 4 x 4
+            nn.ConvTranspose2d(ngf * 8, ngf * 4, 4, 2, 1, bias=False),
+            nn.BatchNorm2d(ngf * 4),
+            nn.ReLU(True),
+            # state size. (ngf*4) x 8 x 8
+            nn.ConvTranspose2d(ngf * 4, ngf * 2, 4, 2, 1, bias=False),
+            nn.BatchNorm2d(ngf * 2),
+            nn.ReLU(True),
+            # state size. (ngf*2) x 16 x 16
+            nn.ConvTranspose2d(ngf * 2,     ngf, 4, 2, 1, bias=False),
+            nn.BatchNorm2d(ngf),
+            nn.ReLU(True),
+            # state size. (ngf) x 32 x 32
+            nn.ConvTranspose2d(    ngf,      nc, 4, 2, 1, bias=False),
+            nn.Tanh()
+            # state size. (nc) x 64 x 64
+        )
+
+    def forward(self, input):
+        # EDIT(momohatt): Do not consider the case of parallel
+        # if input.is_cuda and self.ngpu > 1:
+        #     output = nn.parallel.data_parallel(self.main, input, range(self.ngpu))
+        # else:
+        output = self.main(input)
+        return output
+
+
+class Discriminator(nn.Module):
+    def __init__(self, ngpu):
+        super(Discriminator, self).__init__()
+        self.ngpu = ngpu
+        self.main = nn.Sequential(
+            # input is (nc) x 64 x 64
+            nn.Conv2d(nc, ndf, 4, 2, 1, bias=False),
+            nn.LeakyReLU(0.2, inplace=True),
+            # state size. (ndf) x 32 x 32
+            nn.Conv2d(ndf, ndf * 2, 4, 2, 1, bias=False),
+            nn.BatchNorm2d(ndf * 2),
+            nn.LeakyReLU(0.2, inplace=True),
+            # state size. (ndf*2) x 16 x 16
+            nn.Conv2d(ndf * 2, ndf * 4, 4, 2, 1, bias=False),
+            nn.BatchNorm2d(ndf * 4),
+            nn.LeakyReLU(0.2, inplace=True),
+            # state size. (ndf*4) x 8 x 8
+            nn.Conv2d(ndf * 4, ndf * 8, 4, 2, 1, bias=False),
+            nn.BatchNorm2d(ndf * 8),
+            nn.LeakyReLU(0.2, inplace=True),
+            # state size. (ndf*8) x 4 x 4
+            nn.Conv2d(ndf * 8, 1, 4, 1, 0, bias=False),
+            nn.Sigmoid()
+        )
+
+    def forward(self, input):
+        # EDIT(momohatt): Do not consider the case of parallel
+        # if input.is_cuda and self.ngpu > 1:
+        #     output = nn.parallel.data_parallel(self.main, input, range(self.ngpu))
+        # else:
+        output = self.main(input)
+
+        return output.view(-1, 1).squeeze(dim=1) # EDIT(momohatt): Add 'dim='
+
+
+def gen_DCGAN_Generator_test():
+    model = Generator(1)
+    x = torch.rand(bs, nz, 1, 1)
+    return model, (x,)
+
+
+def gen_DCGAN_Discriminator_test():
+    model = Discriminator(1)
+    x = Generator(1)(torch.rand(bs, nz, 1, 1))
+    return model, (x,)

--- a/testcases/pytorch/examples/mnist.py
+++ b/testcases/pytorch/examples/mnist.py
@@ -1,0 +1,37 @@
+# from https://github.com/pytorch/examples/blob/master/mnist/main.py
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class Net(nn.Module):
+    def __init__(self):
+        super(Net, self).__init__()
+        self.conv1 = nn.Conv2d(1, 32, 3, 1)
+        self.conv2 = nn.Conv2d(32, 64, 3, 1)
+        self.dropout1 = nn.Dropout2d(0.25)
+        self.dropout2 = nn.Dropout2d(0.5)
+        self.fc1 = nn.Linear(9216, 128)
+        self.fc2 = nn.Linear(128, 10)
+
+    def forward(self, x):
+        x = self.conv1(x)
+        x = F.relu(x)
+        x = self.conv2(x)
+        x = F.max_pool2d(x, 2)
+        x = self.dropout1(x)
+        x = torch.flatten(x, start_dim=1) # EDIT(momohatt): Add 'start_dim='
+        x = self.fc1(x)
+        x = F.relu(x)
+        x = self.dropout2(x)
+        x = self.fc2(x)
+        output = F.log_softmax(x, dim=1)
+        return output
+
+
+# Generate the model instance and arguments
+def gen_MNIST_test():
+    model = Net()
+    x = torch.rand(64, 1, 28, 28)
+    return model, (x,)

--- a/testcases/pytorch/examples/mnist_hogwild.py
+++ b/testcases/pytorch/examples/mnist_hogwild.py
@@ -1,0 +1,30 @@
+# https://github.com/pytorch/examples/blob/master/mnist_hogwild/main.py
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+class Net(nn.Module):
+    def __init__(self):
+        super(Net, self).__init__()
+        self.conv1 = nn.Conv2d(1, 10, kernel_size=5)
+        self.conv2 = nn.Conv2d(10, 20, kernel_size=5)
+        self.conv2_drop = nn.Dropout2d()
+        self.fc1 = nn.Linear(320, 50)
+        self.fc2 = nn.Linear(50, 10)
+
+    def forward(self, x):
+        x = F.relu(F.max_pool2d(self.conv1(x), 2))
+        x = F.relu(F.max_pool2d(self.conv2_drop(self.conv2(x)), 2))
+        x = x.view(-1, 320)
+        x = F.relu(self.fc1(x))
+        x = F.dropout(x, training=self.training)
+        x = self.fc2(x)
+        return F.log_softmax(x, dim=1)
+
+
+ # Generate the model instance and arguments
+def gen_MNIST_hogwild_test():
+    model = Net()
+    x = torch.rand(64, 1, 28, 28)
+    return model, (x,)

--- a/testcases/pytorch/examples/super_resolution.py
+++ b/testcases/pytorch/examples/super_resolution.py
@@ -1,0 +1,38 @@
+# from https://github.com/pytorch/examples/blob/master/super_resolution/model.py
+
+import torch
+import torch.nn as nn
+import torch.nn.init as init
+
+
+class Net(nn.Module):
+    def __init__(self, upscale_factor):
+        super(Net, self).__init__()
+
+        self.relu = nn.ReLU()
+        self.conv1 = nn.Conv2d(1, 64, (5, 5), (1, 1), (2, 2))
+        self.conv2 = nn.Conv2d(64, 64, (3, 3), (1, 1), (1, 1))
+        self.conv3 = nn.Conv2d(64, 32, (3, 3), (1, 1), (1, 1))
+        self.conv4 = nn.Conv2d(32, upscale_factor ** 2, (3, 3), (1, 1), (1, 1))
+        self.pixel_shuffle = nn.PixelShuffle(upscale_factor)
+
+        self._initialize_weights()
+
+    def forward(self, x):
+        x = self.relu(self.conv1(x))
+        x = self.relu(self.conv2(x))
+        x = self.relu(self.conv3(x))
+        x = self.pixel_shuffle(self.conv4(x))
+        return x
+
+    def _initialize_weights(self):
+        init.orthogonal_(self.conv1.weight, init.calculate_gain('relu'))
+        init.orthogonal_(self.conv2.weight, init.calculate_gain('relu'))
+        init.orthogonal_(self.conv3.weight, init.calculate_gain('relu'))
+        init.orthogonal_(self.conv4.weight)
+
+
+def gen_SuperResolution_test():
+    model = Net(upscale_factor=4)
+    x = torch.rand(5, 1, 32, 32)
+    return model, (x,)

--- a/testcases/pytorch/examples/time_sequence_prediction.py
+++ b/testcases/pytorch/examples/time_sequence_prediction.py
@@ -1,0 +1,40 @@
+# https://github.com/pytorch/examples/blob/master/time_sequence_prediction/train.py
+
+import torch
+import torch.nn as nn
+
+class Sequence(nn.Module):
+    def __init__(self):
+        super(Sequence, self).__init__()
+        self.lstm1 = nn.LSTMCell(1, 51)
+        self.lstm2 = nn.LSTMCell(51, 51)
+        self.linear = nn.Linear(51, 1)
+
+    def forward(self, input, future):
+        outputs = []
+        h_t  = torch.zeros(input.size(0), 51, dtype=torch.double)
+        c_t  = torch.zeros(input.size(0), 51, dtype=torch.double)
+        h_t2 = torch.zeros(input.size(0), 51, dtype=torch.double)
+        c_t2 = torch.zeros(input.size(0), 51, dtype=torch.double)
+
+        for i, input_t in enumerate(input.chunk(input.size(1), dim=1)):
+            h_t, c_t = self.lstm1(input_t, (h_t, c_t))
+            h_t2, c_t2 = self.lstm2(h_t, (h_t2, c_t2))
+            output = self.linear(h_t2)
+            outputs += [output]
+        for i in range(future):# if we should predict the future
+            h_t, c_t = self.lstm1(output, (h_t, c_t))
+            h_t2, c_t2 = self.lstm2(h_t, (h_t2, c_t2))
+            output = self.linear(h_t2)
+            outputs += [output]
+        # EDIT(momohatt): Add 'dim='
+        outputs = torch.stack(outputs, dim=1).squeeze(dim=2)
+        return outputs
+
+
+def gen_Sequence_test():
+    model = Sequence()
+    model.double()
+    x = torch.rand(3, 4)
+    future = 0
+    return model, (x, future)

--- a/testcases/pytorch/examples/transformer_net.py
+++ b/testcases/pytorch/examples/transformer_net.py
@@ -1,0 +1,107 @@
+# from https://github.com/pytorch/examples/blob/master/fast_neural_style/neural_style/transformer_net.py
+
+import torch
+
+
+class TransformerNet(torch.nn.Module):
+    def __init__(self):
+        super(TransformerNet, self).__init__()
+        # Initial convolution layers
+        self.conv1 = ConvLayer(3, 32, kernel_size=9, stride=1)
+        self.in1 = torch.nn.InstanceNorm2d(32, affine=True)
+        self.conv2 = ConvLayer(32, 64, kernel_size=3, stride=2)
+        self.in2 = torch.nn.InstanceNorm2d(64, affine=True)
+        self.conv3 = ConvLayer(64, 128, kernel_size=3, stride=2)
+        self.in3 = torch.nn.InstanceNorm2d(128, affine=True)
+        # Residual layers
+        self.res1 = ResidualBlock(128)
+        self.res2 = ResidualBlock(128)
+        self.res3 = ResidualBlock(128)
+        self.res4 = ResidualBlock(128)
+        self.res5 = ResidualBlock(128)
+        # Upsampling Layers
+        self.deconv1 = UpsampleConvLayer(128, 64, kernel_size=3, stride=1, upsample=2)
+        self.in4 = torch.nn.InstanceNorm2d(64, affine=True)
+        self.deconv2 = UpsampleConvLayer(64, 32, kernel_size=3, stride=1, upsample=2)
+        self.in5 = torch.nn.InstanceNorm2d(32, affine=True)
+        self.deconv3 = ConvLayer(32, 3, kernel_size=9, stride=1)
+        # Non-linearities
+        self.relu = torch.nn.ReLU()
+
+    def forward(self, X):
+        y = self.relu(self.in1(self.conv1(X)))
+        y = self.relu(self.in2(self.conv2(y)))
+        y = self.relu(self.in3(self.conv3(y)))
+        y = self.res1(y)
+        y = self.res2(y)
+        y = self.res3(y)
+        y = self.res4(y)
+        y = self.res5(y)
+        y = self.relu(self.in4(self.deconv1(y)))
+        y = self.relu(self.in5(self.deconv2(y)))
+        y = self.deconv3(y)
+        return y
+
+
+class ConvLayer(torch.nn.Module):
+    def __init__(self, in_channels, out_channels, kernel_size, stride):
+        super(ConvLayer, self).__init__()
+        reflection_padding = kernel_size // 2
+        self.reflection_pad = torch.nn.ReflectionPad2d(reflection_padding)
+        self.conv2d = torch.nn.Conv2d(in_channels, out_channels, kernel_size, stride)
+
+    def forward(self, x):
+        out = self.reflection_pad(x)
+        out = self.conv2d(out)
+        return out
+
+
+class ResidualBlock(torch.nn.Module):
+    """ResidualBlock
+    introduced in: https://arxiv.org/abs/1512.03385
+    recommended architecture: http://torch.ch/blog/2016/02/04/resnets.html
+    """
+
+    def __init__(self, channels):
+        super(ResidualBlock, self).__init__()
+        self.conv1 = ConvLayer(channels, channels, kernel_size=3, stride=1)
+        self.in1 = torch.nn.InstanceNorm2d(channels, affine=True)
+        self.conv2 = ConvLayer(channels, channels, kernel_size=3, stride=1)
+        self.in2 = torch.nn.InstanceNorm2d(channels, affine=True)
+        self.relu = torch.nn.ReLU()
+
+    def forward(self, x):
+        residual = x
+        out = self.relu(self.in1(self.conv1(x)))
+        out = self.in2(self.conv2(out))
+        out = out + residual
+        return out
+
+
+class UpsampleConvLayer(torch.nn.Module):
+    """UpsampleConvLayer
+    Upsamples the input and then does a convolution. This method gives better results
+    compared to ConvTranspose2d.
+    ref: http://distill.pub/2016/deconv-checkerboard/
+    """
+
+    def __init__(self, in_channels, out_channels, kernel_size, stride, upsample=None):
+        super(UpsampleConvLayer, self).__init__()
+        self.upsample = upsample
+        reflection_padding = kernel_size // 2
+        self.reflection_pad = torch.nn.ReflectionPad2d(reflection_padding)
+        self.conv2d = torch.nn.Conv2d(in_channels, out_channels, kernel_size, stride)
+
+    def forward(self, x):
+        x_in = x
+        if self.upsample:
+            x_in = torch.nn.functional.interpolate(x_in, mode='nearest', scale_factor=self.upsample)
+        out = self.reflection_pad(x_in)
+        out = self.conv2d(out)
+        return out
+
+
+def gen_TransformerNet_test():
+    model = TransformerNet()
+    x = torch.rand(5, 3, 16, 16)
+    return model, (x,)

--- a/testcases/pytorch/examples/vae.py
+++ b/testcases/pytorch/examples/vae.py
@@ -1,0 +1,43 @@
+# https://github.com/pytorch/examples/blob/master/vae/main.py
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class VAE(nn.Module):
+    def __init__(self):
+        super(VAE, self).__init__()
+
+        self.fc1 = nn.Linear(784, 400)
+        self.fc21 = nn.Linear(400, 20)
+        self.fc22 = nn.Linear(400, 20)
+        self.fc3 = nn.Linear(20, 400)
+        self.fc4 = nn.Linear(400, 784)
+
+    def encode(self, x):
+        h1 = F.relu(self.fc1(x))
+        return self.fc21(h1), self.fc22(h1)
+
+    def reparameterize(self, mu, logvar):
+        if self.training:
+            std = torch.exp(0.5 * logvar)
+            eps = torch.randn_like(std)
+            return eps.mul(std).add_(mu)
+        else:
+            return mu
+
+    def decode(self, z):
+        h3 = F.relu(self.fc3(z))
+        return torch.sigmoid(self.fc4(h3))
+
+    def forward(self, x):
+        mu, logvar = self.encode(x.view(-1, 784))
+        z = self.reparameterize(mu, logvar)
+        return self.decode(z), mu, logvar
+
+
+def gen_VAE_test():
+    model = VAE()
+    x = torch.rand(128, 1, 28, 28)
+    return model, (x,)

--- a/tests/elichika_typing/pytorch/examples/dcgan_test.py
+++ b/tests/elichika_typing/pytorch/examples/dcgan_test.py
@@ -1,0 +1,59 @@
+import torch
+import torch.nn as nn
+import unittest
+
+from chainer_compiler.elichika.testtools import generate_id2type_from_forward
+from chainer_compiler.elichika.testtools import type_inference_tools
+
+from testcases.pytorch.examples.dcgan import gen_DCGAN_Generator_test
+from testcases.pytorch.examples.dcgan import gen_DCGAN_Discriminator_test
+
+
+class TestDCGAN(unittest.TestCase):
+    def test_DCGAN_Generator(self):
+        type_inference_tools.reset_state()
+
+        model, forward_args = gen_DCGAN_Generator_test()
+        id2type = generate_id2type_from_forward(model, forward_args)
+
+        self.assertEqual(str(id2type[1]), "class Generator -> torch.Tensor(float32, (5, 6, 1, 1)) -> torch.Tensor(float32, (5, 3, 64, 64))")	# FunctionDef forward (line 1)
+        self.assertEqual(str(id2type[7]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[8]), "torch.Tensor(float32, (5, 3, 64, 64))")	# Name output (line 6)
+        self.assertEqual(str(id2type[10]), "torch.Tensor(float32, (5, 3, 64, 64))")	# Call self.main(input) (line 6)
+        self.assertEqual(str(id2type[11]), "torch.Tensor(float32, (5, 6, 1, 1)) -> torch.Tensor(float32, (5, 3, 64, 64))")	# Attribute self.main (line 6)
+        self.assertEqual(str(id2type[12]), "class Generator")	# Name self (line 6)
+        self.assertEqual(str(id2type[15]), "torch.Tensor(float32, (5, 6, 1, 1))")	# Name input (line 6)
+        self.assertEqual(str(id2type[17]), "torch.Tensor(float32, (5, 3, 64, 64))")	# Return
+        self.assertEqual(str(id2type[18]), "torch.Tensor(float32, (5, 3, 64, 64))")	# Name output (line 7)
+
+
+    def test_DCGAN_Discriminator(self):
+        type_inference_tools.reset_state()
+
+        model, forward_args = gen_DCGAN_Discriminator_test()
+        id2type = generate_id2type_from_forward(model, forward_args)
+
+        self.assertEqual(str(id2type[1]), "class Discriminator -> torch.Tensor(float32, (5, 3, 64, 64)) -> torch.Tensor(float32, (5,))")	# FunctionDef forward (line 1)
+        self.assertEqual(str(id2type[7]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[8]), "torch.Tensor(float32, (5, 1, 1, 1))")	# Name output (line 6)
+        self.assertEqual(str(id2type[10]), "torch.Tensor(float32, (5, 1, 1, 1))")	# Call self.main(input) (line 6)
+        self.assertEqual(str(id2type[11]), "torch.Tensor(float32, (5, 3, 64, 64)) -> torch.Tensor(float32, (5, 1, 1, 1))")	# Attribute self.main (line 6)
+        self.assertEqual(str(id2type[12]), "class Discriminator")	# Name self (line 6)
+        self.assertEqual(str(id2type[15]), "torch.Tensor(float32, (5, 3, 64, 64))")	# Name input (line 6)
+        self.assertEqual(str(id2type[17]), "torch.Tensor(float32, (5,))")	# Return
+        self.assertEqual(str(id2type[18]), "torch.Tensor(float32, (5,))")	# Call output.view(-1, 1).squeeze(dim=1) (line 8)
+        self.assertEqual(str(id2type[19]), "(no argument) -> torch.Tensor(float32, (5,))")	# Attribute output.view(-1, 1).squeeze (line 8)
+        self.assertEqual(str(id2type[20]), "torch.Tensor(float32, (5, 1))")	# Call output.view(-1, 1) (line 8)
+        self.assertEqual(str(id2type[21]), "int -> int -> torch.Tensor(float32, (5, 1))")	# Attribute output.view (line 8)
+        self.assertEqual(str(id2type[22]), "torch.Tensor(float32, (5, 1, 1, 1))")	# Name output (line 8)
+        self.assertEqual(str(id2type[25]), "int")	# UnaryOp -1 (line 8)
+        self.assertEqual(str(id2type[27]), "int")	# Constant 1 (line 8)
+        self.assertEqual(str(id2type[28]), "int")	# Constant 1 (line 8)
+        self.assertEqual(str(id2type[31]), "int")	# Constant 1 (line 8)
+
+
+def main():
+    unittest.main()
+
+if __name__ == '__main__':
+    main()

--- a/tests/elichika_typing/pytorch/examples/mnist_hogwild_test.py
+++ b/tests/elichika_typing/pytorch/examples/mnist_hogwild_test.py
@@ -1,0 +1,84 @@
+import torch
+import torch.nn as nn
+import unittest
+
+from chainer_compiler.elichika.testtools import generate_id2type_from_forward
+from chainer_compiler.elichika.testtools import type_inference_tools
+
+from testcases.pytorch.examples.mnist_hogwild import gen_MNIST_hogwild_test
+
+
+class TestMNIST_hogwild(unittest.TestCase):
+    def test_MNIST_hogwild(self):
+        type_inference_tools.reset_state()
+
+        model, forward_args = gen_MNIST_hogwild_test()
+        id2type = generate_id2type_from_forward(model, forward_args)
+
+        self.assertEqual(str(id2type[1]), "class Net -> torch.Tensor(float32, (64, 1, 28, 28)) -> torch.Tensor(float32, (64, 10))")	# FunctionDef forward (line 1)
+        self.assertEqual(str(id2type[7]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[8]), "torch.Tensor(float32, (64, 10, 12, 12))")	# Name x (line 2)
+        self.assertEqual(str(id2type[10]), "torch.Tensor(float32, (64, 10, 12, 12))")	# Call F.relu(F.max_pool2d(self.conv1(x), 2)) (line 2)
+        self.assertEqual(str(id2type[11]), "torch.Tensor(float32, (64, 10, 12, 12)) -> torch.Tensor(float32, (64, 10, 12, 12))")	# Attribute F.relu (line 2)
+        self.assertEqual(str(id2type[15]), "torch.Tensor(float32, (64, 10, 12, 12))")	# Call F.max_pool2d(self.conv1(x), 2) (line 2)
+        self.assertEqual(str(id2type[16]), "torch.Tensor(float32, (64, 10, 24, 24)) -> int -> torch.Tensor(float32, (64, 10, 12, 12))")	# Attribute F.max_pool2d (line 2)
+        self.assertEqual(str(id2type[20]), "torch.Tensor(float32, (64, 10, 24, 24))")	# Call self.conv1(x) (line 2)
+        self.assertEqual(str(id2type[21]), "torch.Tensor(float32, (64, 1, 28, 28)) -> torch.Tensor(float32, (64, 10, 24, 24))")	# Attribute self.conv1 (line 2)
+        self.assertEqual(str(id2type[22]), "class Net")	# Name self (line 2)
+        self.assertEqual(str(id2type[25]), "torch.Tensor(float32, (64, 1, 28, 28))")	# Name x (line 2)
+        self.assertEqual(str(id2type[27]), "int")	# Constant 2 (line 2)
+        self.assertEqual(str(id2type[28]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[29]), "torch.Tensor(float32, (64, 20, 4, 4))")	# Name x (line 3)
+        self.assertEqual(str(id2type[31]), "torch.Tensor(float32, (64, 20, 4, 4))")	# Call F.relu(F.max_pool2d(self.conv2_drop(self.conv2(x)), 2)) (line 3)
+        self.assertEqual(str(id2type[32]), "torch.Tensor(float32, (64, 20, 4, 4)) -> torch.Tensor(float32, (64, 20, 4, 4))")	# Attribute F.relu (line 3)
+        self.assertEqual(str(id2type[36]), "torch.Tensor(float32, (64, 20, 4, 4))")	# Call F.max_pool2d(self.conv2_drop(self.conv2(x)), 2) (line 3)
+        self.assertEqual(str(id2type[37]), "torch.Tensor(float32, (64, 20, 8, 8)) -> int -> torch.Tensor(float32, (64, 20, 4, 4))")	# Attribute F.max_pool2d (line 3)
+        self.assertEqual(str(id2type[41]), "torch.Tensor(float32, (64, 20, 8, 8))")	# Call self.conv2_drop(self.conv2(x)) (line 3)
+        self.assertEqual(str(id2type[42]), "torch.Tensor(float32, (64, 20, 8, 8)) -> torch.Tensor(float32, (64, 20, 8, 8))")	# Attribute self.conv2_drop (line 3)
+        self.assertEqual(str(id2type[43]), "class Net")	# Name self (line 3)
+        self.assertEqual(str(id2type[46]), "torch.Tensor(float32, (64, 20, 8, 8))")	# Call self.conv2(x) (line 3)
+        self.assertEqual(str(id2type[47]), "torch.Tensor(float32, (64, 10, 12, 12)) -> torch.Tensor(float32, (64, 20, 8, 8))")	# Attribute self.conv2 (line 3)
+        self.assertEqual(str(id2type[48]), "class Net")	# Name self (line 3)
+        self.assertEqual(str(id2type[51]), "torch.Tensor(float32, (64, 10, 12, 12))")	# Name x (line 3)
+        self.assertEqual(str(id2type[53]), "int")	# Constant 2 (line 3)
+        self.assertEqual(str(id2type[54]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[55]), "torch.Tensor(float32, (64, 320))")	# Name x (line 4)
+        self.assertEqual(str(id2type[57]), "torch.Tensor(float32, (64, 320))")	# Call x.view(-1, 320) (line 4)
+        self.assertEqual(str(id2type[58]), "int -> int -> torch.Tensor(float32, (64, 320))")	# Attribute x.view (line 4)
+        self.assertEqual(str(id2type[59]), "torch.Tensor(float32, (64, 20, 4, 4))")	# Name x (line 4)
+        self.assertEqual(str(id2type[62]), "int")	# UnaryOp -1 (line 4)
+        self.assertEqual(str(id2type[64]), "int")	# Constant 1 (line 4)
+        self.assertEqual(str(id2type[65]), "int")	# Constant 320 (line 4)
+        self.assertEqual(str(id2type[66]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[67]), "torch.Tensor(float32, (64, 50))")	# Name x (line 5)
+        self.assertEqual(str(id2type[69]), "torch.Tensor(float32, (64, 50))")	# Call F.relu(self.fc1(x)) (line 5)
+        self.assertEqual(str(id2type[70]), "torch.Tensor(float32, (64, 50)) -> torch.Tensor(float32, (64, 50))")	# Attribute F.relu (line 5)
+        self.assertEqual(str(id2type[74]), "torch.Tensor(float32, (64, 50))")	# Call self.fc1(x) (line 5)
+        self.assertEqual(str(id2type[75]), "torch.Tensor(float32, (64, 320)) -> torch.Tensor(float32, (64, 50))")	# Attribute self.fc1 (line 5)
+        self.assertEqual(str(id2type[76]), "class Net")	# Name self (line 5)
+        self.assertEqual(str(id2type[79]), "torch.Tensor(float32, (64, 320))")	# Name x (line 5)
+        self.assertEqual(str(id2type[81]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[82]), "torch.Tensor(float32, (64, 50))")	# Name x (line 6)
+        self.assertEqual(str(id2type[84]), "torch.Tensor(float32, (64, 50))")	# Call F.dropout(x, training=self.training) (line 6)
+        self.assertEqual(str(id2type[85]), "torch.Tensor(float32, (64, 50)) -> torch.Tensor(float32, (64, 50))")	# Attribute F.dropout (line 6)
+        self.assertEqual(str(id2type[89]), "torch.Tensor(float32, (64, 50))")	# Name x (line 6)
+        self.assertEqual(str(id2type[92]), "bool")	# Attribute self.training (line 6)
+        self.assertEqual(str(id2type[93]), "class Net")	# Name self (line 6)
+        self.assertEqual(str(id2type[96]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[97]), "torch.Tensor(float32, (64, 10))")	# Name x (line 7)
+        self.assertEqual(str(id2type[99]), "torch.Tensor(float32, (64, 10))")	# Call self.fc2(x) (line 7)
+        self.assertEqual(str(id2type[100]), "torch.Tensor(float32, (64, 50)) -> torch.Tensor(float32, (64, 10))")	# Attribute self.fc2 (line 7)
+        self.assertEqual(str(id2type[101]), "class Net")	# Name self (line 7)
+        self.assertEqual(str(id2type[104]), "torch.Tensor(float32, (64, 50))")	# Name x (line 7)
+        self.assertEqual(str(id2type[106]), "torch.Tensor(float32, (64, 10))")	# Return
+        self.assertEqual(str(id2type[107]), "torch.Tensor(float32, (64, 10))")	# Call F.log_softmax(x, dim=1) (line 8)
+        self.assertEqual(str(id2type[108]), "torch.Tensor(float32, (64, 10)) -> torch.Tensor(float32, (64, 10))")	# Attribute F.log_softmax (line 8)
+        self.assertEqual(str(id2type[112]), "torch.Tensor(float32, (64, 10))")	# Name x (line 8)
+        self.assertEqual(str(id2type[115]), "int")	# Constant 1 (line 8)
+
+
+def main():
+    unittest.main()
+
+if __name__ == '__main__':
+    main()

--- a/tests/elichika_typing/pytorch/examples/mnist_test.py
+++ b/tests/elichika_typing/pytorch/examples/mnist_test.py
@@ -1,0 +1,91 @@
+import torch
+import torch.nn as nn
+import unittest
+
+from chainer_compiler.elichika.testtools import generate_id2type_from_forward
+from chainer_compiler.elichika.testtools import type_inference_tools
+
+from testcases.pytorch.examples.mnist import gen_MNIST_test
+
+
+class TestMNIST(unittest.TestCase):
+    def test_MNIST(self):
+        type_inference_tools.reset_state()
+
+        model, forward_args = gen_MNIST_test()
+        id2type = generate_id2type_from_forward(model, forward_args)
+
+        self.assertEqual(str(id2type[1]), "class Net -> torch.Tensor(float32, (64, 1, 28, 28)) -> torch.Tensor(float32, (64, 10))")	# FunctionDef forward (line 1)
+        self.assertEqual(str(id2type[7]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[8]), "torch.Tensor(float32, (64, 32, 26, 26))")	# Name x (line 2)
+        self.assertEqual(str(id2type[10]), "torch.Tensor(float32, (64, 32, 26, 26))")	# Call self.conv1(x) (line 2)
+        self.assertEqual(str(id2type[11]), "torch.Tensor(float32, (64, 1, 28, 28)) -> torch.Tensor(float32, (64, 32, 26, 26))")	# Attribute self.conv1 (line 2)
+        self.assertEqual(str(id2type[12]), "class Net")	# Name self (line 2)
+        self.assertEqual(str(id2type[15]), "torch.Tensor(float32, (64, 1, 28, 28))")	# Name x (line 2)
+        self.assertEqual(str(id2type[17]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[18]), "torch.Tensor(float32, (64, 32, 26, 26))")	# Name x (line 3)
+        self.assertEqual(str(id2type[20]), "torch.Tensor(float32, (64, 32, 26, 26))")	# Call F.relu(x) (line 3)
+        self.assertEqual(str(id2type[21]), "torch.Tensor(float32, (64, 32, 26, 26)) -> torch.Tensor(float32, (64, 32, 26, 26))")	# Attribute F.relu (line 3)
+        self.assertEqual(str(id2type[25]), "torch.Tensor(float32, (64, 32, 26, 26))")	# Name x (line 3)
+        self.assertEqual(str(id2type[27]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[28]), "torch.Tensor(float32, (64, 64, 24, 24))")	# Name x (line 4)
+        self.assertEqual(str(id2type[30]), "torch.Tensor(float32, (64, 64, 24, 24))")	# Call self.conv2(x) (line 4)
+        self.assertEqual(str(id2type[31]), "torch.Tensor(float32, (64, 32, 26, 26)) -> torch.Tensor(float32, (64, 64, 24, 24))")	# Attribute self.conv2 (line 4)
+        self.assertEqual(str(id2type[32]), "class Net")	# Name self (line 4)
+        self.assertEqual(str(id2type[35]), "torch.Tensor(float32, (64, 32, 26, 26))")	# Name x (line 4)
+        self.assertEqual(str(id2type[37]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[38]), "torch.Tensor(float32, (64, 64, 12, 12))")	# Name x (line 5)
+        self.assertEqual(str(id2type[40]), "torch.Tensor(float32, (64, 64, 12, 12))")	# Call F.max_pool2d(x, 2) (line 5)
+        self.assertEqual(str(id2type[41]), "torch.Tensor(float32, (64, 64, 24, 24)) -> int -> torch.Tensor(float32, (64, 64, 12, 12))")	# Attribute F.max_pool2d (line 5)
+        self.assertEqual(str(id2type[45]), "torch.Tensor(float32, (64, 64, 24, 24))")	# Name x (line 5)
+        self.assertEqual(str(id2type[47]), "int")	# Constant 2 (line 5)
+        self.assertEqual(str(id2type[48]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[49]), "torch.Tensor(float32, (64, 64, 12, 12))")	# Name x (line 6)
+        self.assertEqual(str(id2type[51]), "torch.Tensor(float32, (64, 64, 12, 12))")	# Call self.dropout1(x) (line 6)
+        self.assertEqual(str(id2type[52]), "torch.Tensor(float32, (64, 64, 12, 12)) -> torch.Tensor(float32, (64, 64, 12, 12))")	# Attribute self.dropout1 (line 6)
+        self.assertEqual(str(id2type[53]), "class Net")	# Name self (line 6)
+        self.assertEqual(str(id2type[56]), "torch.Tensor(float32, (64, 64, 12, 12))")	# Name x (line 6)
+        self.assertEqual(str(id2type[58]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[59]), "torch.Tensor(float32, (64, 9216))")	# Name x (line 7)
+        self.assertEqual(str(id2type[61]), "torch.Tensor(float32, (64, 9216))")	# Call torch.flatten(x, start_dim=1) (line 7)
+        self.assertEqual(str(id2type[62]), "torch.Tensor(float32, (64, 64, 12, 12)) -> torch.Tensor(float32, (64, 9216))")	# Attribute torch.flatten (line 7)
+        self.assertEqual(str(id2type[66]), "torch.Tensor(float32, (64, 64, 12, 12))")	# Name x (line 7)
+        self.assertEqual(str(id2type[69]), "int")	# Constant 1 (line 7)
+        self.assertEqual(str(id2type[70]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[71]), "torch.Tensor(float32, (64, 128))")	# Name x (line 8)
+        self.assertEqual(str(id2type[73]), "torch.Tensor(float32, (64, 128))")	# Call self.fc1(x) (line 8)
+        self.assertEqual(str(id2type[74]), "torch.Tensor(float32, (64, 9216)) -> torch.Tensor(float32, (64, 128))")	# Attribute self.fc1 (line 8)
+        self.assertEqual(str(id2type[75]), "class Net")	# Name self (line 8)
+        self.assertEqual(str(id2type[78]), "torch.Tensor(float32, (64, 9216))")	# Name x (line 8)
+        self.assertEqual(str(id2type[80]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[81]), "torch.Tensor(float32, (64, 128))")	# Name x (line 9)
+        self.assertEqual(str(id2type[83]), "torch.Tensor(float32, (64, 128))")	# Call F.relu(x) (line 9)
+        self.assertEqual(str(id2type[84]), "torch.Tensor(float32, (64, 128)) -> torch.Tensor(float32, (64, 128))")	# Attribute F.relu (line 9)
+        self.assertEqual(str(id2type[88]), "torch.Tensor(float32, (64, 128))")	# Name x (line 9)
+        self.assertEqual(str(id2type[90]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[91]), "torch.Tensor(float32, (64, 128))")	# Name x (line 10)
+        self.assertEqual(str(id2type[93]), "torch.Tensor(float32, (64, 128))")	# Call self.dropout2(x) (line 10)
+        self.assertEqual(str(id2type[94]), "torch.Tensor(float32, (64, 128)) -> torch.Tensor(float32, (64, 128))")	# Attribute self.dropout2 (line 10)
+        self.assertEqual(str(id2type[95]), "class Net")	# Name self (line 10)
+        self.assertEqual(str(id2type[98]), "torch.Tensor(float32, (64, 128))")	# Name x (line 10)
+        self.assertEqual(str(id2type[100]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[101]), "torch.Tensor(float32, (64, 10))")	# Name x (line 11)
+        self.assertEqual(str(id2type[103]), "torch.Tensor(float32, (64, 10))")	# Call self.fc2(x) (line 11)
+        self.assertEqual(str(id2type[104]), "torch.Tensor(float32, (64, 128)) -> torch.Tensor(float32, (64, 10))")	# Attribute self.fc2 (line 11)
+        self.assertEqual(str(id2type[105]), "class Net")	# Name self (line 11)
+        self.assertEqual(str(id2type[108]), "torch.Tensor(float32, (64, 128))")	# Name x (line 11)
+        self.assertEqual(str(id2type[110]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[111]), "torch.Tensor(float32, (64, 10))")	# Name output (line 12)
+        self.assertEqual(str(id2type[113]), "torch.Tensor(float32, (64, 10))")	# Call F.log_softmax(x, dim=1) (line 12)
+        self.assertEqual(str(id2type[114]), "torch.Tensor(float32, (64, 10)) -> torch.Tensor(float32, (64, 10))")	# Attribute F.log_softmax (line 12)
+        self.assertEqual(str(id2type[118]), "torch.Tensor(float32, (64, 10))")	# Name x (line 12)
+        self.assertEqual(str(id2type[121]), "int")	# Constant 1 (line 12)
+        self.assertEqual(str(id2type[122]), "torch.Tensor(float32, (64, 10))")	# Return
+        self.assertEqual(str(id2type[123]), "torch.Tensor(float32, (64, 10))")	# Name output (line 13)
+
+
+def main():
+    unittest.main()
+
+if __name__ == '__main__':
+    main()

--- a/tests/elichika_typing/pytorch/examples/super_resolution_test.py
+++ b/tests/elichika_typing/pytorch/examples/super_resolution_test.py
@@ -1,0 +1,63 @@
+import torch
+import torch.nn as nn
+import unittest
+
+from chainer_compiler.elichika.testtools import generate_id2type_from_forward
+from chainer_compiler.elichika.testtools import type_inference_tools
+
+from testcases.pytorch.examples.super_resolution import gen_SuperResolution_test
+
+
+class TestSuperResolution(unittest.TestCase):
+    def test_SuperResolution(self):
+        type_inference_tools.reset_state()
+
+        model, forward_args = gen_SuperResolution_test()
+        id2type = generate_id2type_from_forward(model, forward_args)
+
+        self.assertEqual(str(id2type[1]), "class Net -> torch.Tensor(float32, (5, 1, 32, 32)) -> torch.Tensor(float32, (5, 1, 128, 128))")	# FunctionDef forward (line 1)
+        self.assertEqual(str(id2type[7]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[8]), "torch.Tensor(float32, (5, 64, 32, 32))")	# Name x (line 2)
+        self.assertEqual(str(id2type[10]), "torch.Tensor(float32, (5, 64, 32, 32))")	# Call self.relu(self.conv1(x)) (line 2)
+        self.assertEqual(str(id2type[11]), "torch.Tensor(float32, (5, 64, 32, 32)) -> torch.Tensor(float32, (5, 64, 32, 32))")	# Attribute self.relu (line 2)
+        self.assertEqual(str(id2type[12]), "class Net")	# Name self (line 2)
+        self.assertEqual(str(id2type[15]), "torch.Tensor(float32, (5, 64, 32, 32))")	# Call self.conv1(x) (line 2)
+        self.assertEqual(str(id2type[16]), "torch.Tensor(float32, (5, 1, 32, 32)) -> torch.Tensor(float32, (5, 64, 32, 32))")	# Attribute self.conv1 (line 2)
+        self.assertEqual(str(id2type[17]), "class Net")	# Name self (line 2)
+        self.assertEqual(str(id2type[20]), "torch.Tensor(float32, (5, 1, 32, 32))")	# Name x (line 2)
+        self.assertEqual(str(id2type[22]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[23]), "torch.Tensor(float32, (5, 64, 32, 32))")	# Name x (line 3)
+        self.assertEqual(str(id2type[25]), "torch.Tensor(float32, (5, 64, 32, 32))")	# Call self.relu(self.conv2(x)) (line 3)
+        self.assertEqual(str(id2type[26]), "torch.Tensor(float32, (5, 64, 32, 32)) -> torch.Tensor(float32, (5, 64, 32, 32))")	# Attribute self.relu (line 3)
+        self.assertEqual(str(id2type[27]), "class Net")	# Name self (line 3)
+        self.assertEqual(str(id2type[30]), "torch.Tensor(float32, (5, 64, 32, 32))")	# Call self.conv2(x) (line 3)
+        self.assertEqual(str(id2type[31]), "torch.Tensor(float32, (5, 64, 32, 32)) -> torch.Tensor(float32, (5, 64, 32, 32))")	# Attribute self.conv2 (line 3)
+        self.assertEqual(str(id2type[32]), "class Net")	# Name self (line 3)
+        self.assertEqual(str(id2type[35]), "torch.Tensor(float32, (5, 64, 32, 32))")	# Name x (line 3)
+        self.assertEqual(str(id2type[37]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[38]), "torch.Tensor(float32, (5, 32, 32, 32))")	# Name x (line 4)
+        self.assertEqual(str(id2type[40]), "torch.Tensor(float32, (5, 32, 32, 32))")	# Call self.relu(self.conv3(x)) (line 4)
+        self.assertEqual(str(id2type[41]), "torch.Tensor(float32, (5, 32, 32, 32)) -> torch.Tensor(float32, (5, 32, 32, 32))")	# Attribute self.relu (line 4)
+        self.assertEqual(str(id2type[42]), "class Net")	# Name self (line 4)
+        self.assertEqual(str(id2type[45]), "torch.Tensor(float32, (5, 32, 32, 32))")	# Call self.conv3(x) (line 4)
+        self.assertEqual(str(id2type[46]), "torch.Tensor(float32, (5, 64, 32, 32)) -> torch.Tensor(float32, (5, 32, 32, 32))")	# Attribute self.conv3 (line 4)
+        self.assertEqual(str(id2type[47]), "class Net")	# Name self (line 4)
+        self.assertEqual(str(id2type[50]), "torch.Tensor(float32, (5, 64, 32, 32))")	# Name x (line 4)
+        self.assertEqual(str(id2type[52]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[53]), "torch.Tensor(float32, (5, 1, 128, 128))")	# Name x (line 5)
+        self.assertEqual(str(id2type[55]), "torch.Tensor(float32, (5, 1, 128, 128))")	# Call self.pixel_shuffle(self.conv4(x)) (line 5)
+        self.assertEqual(str(id2type[56]), "torch.Tensor(float32, (5, 16, 32, 32)) -> torch.Tensor(float32, (5, 1, 128, 128))")	# Attribute self.pixel_shuffle (line 5)
+        self.assertEqual(str(id2type[57]), "class Net")	# Name self (line 5)
+        self.assertEqual(str(id2type[60]), "torch.Tensor(float32, (5, 16, 32, 32))")	# Call self.conv4(x) (line 5)
+        self.assertEqual(str(id2type[61]), "torch.Tensor(float32, (5, 32, 32, 32)) -> torch.Tensor(float32, (5, 16, 32, 32))")	# Attribute self.conv4 (line 5)
+        self.assertEqual(str(id2type[62]), "class Net")	# Name self (line 5)
+        self.assertEqual(str(id2type[65]), "torch.Tensor(float32, (5, 32, 32, 32))")	# Name x (line 5)
+        self.assertEqual(str(id2type[67]), "torch.Tensor(float32, (5, 1, 128, 128))")	# Return
+        self.assertEqual(str(id2type[68]), "torch.Tensor(float32, (5, 1, 128, 128))")	# Name x (line 6)
+
+
+def main():
+    unittest.main()
+
+if __name__ == '__main__':
+    main()

--- a/tests/elichika_typing/pytorch/examples/time_sequence_prediction_test.py
+++ b/tests/elichika_typing/pytorch/examples/time_sequence_prediction_test.py
@@ -1,0 +1,164 @@
+import torch
+import torch.nn as nn
+import unittest
+
+from chainer_compiler.elichika.testtools import generate_id2type_from_forward
+from chainer_compiler.elichika.testtools import type_inference_tools
+
+from testcases.pytorch.examples.time_sequence_prediction import gen_Sequence_test
+
+
+class TestSequence(unittest.TestCase):
+    def test_Sequence(self):
+        type_inference_tools.reset_state()
+
+        model, forward_args = gen_Sequence_test()
+        id2type = generate_id2type_from_forward(model, forward_args)
+
+        self.assertEqual(str(id2type[1]), "class Sequence -> torch.Tensor(float32, (3, 4)) -> int -> torch.Tensor(float64, (3, None))")	# FunctionDef forward (line 1)
+        self.assertEqual(str(id2type[9]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[10]), "[]")	# Name outputs (line 2)
+        self.assertEqual(str(id2type[12]), "[]")	# List [] (line 2)
+        self.assertEqual(str(id2type[14]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[15]), "torch.Tensor(float64, (3, 51))")	# Name h_t (line 3)
+        self.assertEqual(str(id2type[17]), "torch.Tensor(float64, (3, 51))")	# Call torch.zeros(input.size(0), 51, dtype=torch.double) (line 3)
+        self.assertEqual(str(id2type[18]), "int -> int -> torch.Tensor(float64, (3, 51))")	# Attribute torch.zeros (line 3)
+        self.assertEqual(str(id2type[22]), "int")	# Call input.size(0) (line 3)
+        self.assertEqual(str(id2type[23]), "int -> int")	# Attribute input.size (line 3)
+        self.assertEqual(str(id2type[24]), "torch.Tensor(float32, (3, 4))")	# Name input (line 3)
+        self.assertEqual(str(id2type[27]), "int")	# Constant 0 (line 3)
+        self.assertEqual(str(id2type[28]), "int")	# Constant 51 (line 3)
+        self.assertEqual(str(id2type[30]), "dtype(float64)")	# Attribute torch.double (line 3)
+        self.assertEqual(str(id2type[34]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[35]), "torch.Tensor(float64, (3, 51))")	# Name c_t (line 4)
+        self.assertEqual(str(id2type[37]), "torch.Tensor(float64, (3, 51))")	# Call torch.zeros(input.size(0), 51, dtype=torch.double) (line 4)
+        self.assertEqual(str(id2type[38]), "int -> int -> torch.Tensor(float64, (3, 51))")	# Attribute torch.zeros (line 4)
+        self.assertEqual(str(id2type[42]), "int")	# Call input.size(0) (line 4)
+        self.assertEqual(str(id2type[43]), "int -> int")	# Attribute input.size (line 4)
+        self.assertEqual(str(id2type[44]), "torch.Tensor(float32, (3, 4))")	# Name input (line 4)
+        self.assertEqual(str(id2type[47]), "int")	# Constant 0 (line 4)
+        self.assertEqual(str(id2type[48]), "int")	# Constant 51 (line 4)
+        self.assertEqual(str(id2type[50]), "dtype(float64)")	# Attribute torch.double (line 4)
+        self.assertEqual(str(id2type[54]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[55]), "torch.Tensor(float64, (3, 51))")	# Name h_t2 (line 5)
+        self.assertEqual(str(id2type[57]), "torch.Tensor(float64, (3, 51))")	# Call torch.zeros(input.size(0), 51, dtype=torch.double) (line 5)
+        self.assertEqual(str(id2type[58]), "int -> int -> torch.Tensor(float64, (3, 51))")	# Attribute torch.zeros (line 5)
+        self.assertEqual(str(id2type[62]), "int")	# Call input.size(0) (line 5)
+        self.assertEqual(str(id2type[63]), "int -> int")	# Attribute input.size (line 5)
+        self.assertEqual(str(id2type[64]), "torch.Tensor(float32, (3, 4))")	# Name input (line 5)
+        self.assertEqual(str(id2type[67]), "int")	# Constant 0 (line 5)
+        self.assertEqual(str(id2type[68]), "int")	# Constant 51 (line 5)
+        self.assertEqual(str(id2type[70]), "dtype(float64)")	# Attribute torch.double (line 5)
+        self.assertEqual(str(id2type[74]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[75]), "torch.Tensor(float64, (3, 51))")	# Name c_t2 (line 6)
+        self.assertEqual(str(id2type[77]), "torch.Tensor(float64, (3, 51))")	# Call torch.zeros(input.size(0), 51, dtype=torch.double) (line 6)
+        self.assertEqual(str(id2type[78]), "int -> int -> torch.Tensor(float64, (3, 51))")	# Attribute torch.zeros (line 6)
+        self.assertEqual(str(id2type[82]), "int")	# Call input.size(0) (line 6)
+        self.assertEqual(str(id2type[83]), "int -> int")	# Attribute input.size (line 6)
+        self.assertEqual(str(id2type[84]), "torch.Tensor(float32, (3, 4))")	# Name input (line 6)
+        self.assertEqual(str(id2type[87]), "int")	# Constant 0 (line 6)
+        self.assertEqual(str(id2type[88]), "int")	# Constant 51 (line 6)
+        self.assertEqual(str(id2type[90]), "dtype(float64)")	# Attribute torch.double (line 6)
+        self.assertEqual(str(id2type[94]), "NoneType")	# For
+        self.assertEqual(str(id2type[95]), "(int, torch.Tensor(float32, (3, 1)))")	# Tuple (i, input_t) (line 8)
+        self.assertEqual(str(id2type[96]), "int")	# Name i (line 8)
+        self.assertEqual(str(id2type[98]), "torch.Tensor(float32, (3, 1))")	# Name input_t (line 8)
+        self.assertEqual(str(id2type[101]), "(int, torch.Tensor(float32, (3, 1))) list")	# Call enumerate(input.chunk(input.size(1), dim=1)) (line 8)
+        self.assertEqual(str(id2type[102]), "(torch.Tensor(float32, (3, 1)), torch.Tensor(float32, (3, 1)), torch.Tensor(float32, (3, 1)), torch.Tensor(float32, (3, 1))) -> (int, torch.Tensor(float32, (3, 1))) list")	# Name enumerate (line 8)
+        self.assertEqual(str(id2type[104]), "(torch.Tensor(float32, (3, 1)), torch.Tensor(float32, (3, 1)), torch.Tensor(float32, (3, 1)), torch.Tensor(float32, (3, 1)))")	# Call input.chunk(input.size(1), dim=1) (line 8)
+        self.assertEqual(str(id2type[105]), "int -> (torch.Tensor(float32, (3, 1)), torch.Tensor(float32, (3, 1)), torch.Tensor(float32, (3, 1)), torch.Tensor(float32, (3, 1)))")	# Attribute input.chunk (line 8)
+        self.assertEqual(str(id2type[106]), "torch.Tensor(float32, (3, 4))")	# Name input (line 8)
+        self.assertEqual(str(id2type[109]), "int")	# Call input.size(1) (line 8)
+        self.assertEqual(str(id2type[110]), "int -> int")	# Attribute input.size (line 8)
+        self.assertEqual(str(id2type[111]), "torch.Tensor(float32, (3, 4))")	# Name input (line 8)
+        self.assertEqual(str(id2type[114]), "int")	# Constant 1 (line 8)
+        self.assertEqual(str(id2type[116]), "int")	# Constant 1 (line 8)
+        self.assertEqual(str(id2type[117]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[118]), "(torch.Tensor(float64, (3, 51)), torch.Tensor(float64, (3, 51)))")	# Tuple (h_t, c_t) (line 9)
+        self.assertEqual(str(id2type[119]), "torch.Tensor(float64, (3, 51))")	# Name h_t (line 9)
+        self.assertEqual(str(id2type[121]), "torch.Tensor(float64, (3, 51))")	# Name c_t (line 9)
+        self.assertEqual(str(id2type[124]), "(torch.Tensor(float64, (3, 51)), torch.Tensor(float64, (3, 51)))")	# Call self.lstm1(input_t, (h_t, c_t)) (line 9)
+        self.assertEqual(str(id2type[125]), "torch.Tensor(float32, (3, 1)) -> (torch.Tensor(float64, (3, 51)), torch.Tensor(float64, (3, 51))) -> (torch.Tensor(float64, (3, 51)), torch.Tensor(float64, (3, 51)))")	# Attribute self.lstm1 (line 9)
+        self.assertEqual(str(id2type[126]), "class Sequence")	# Name self (line 9)
+        self.assertEqual(str(id2type[129]), "torch.Tensor(float32, (3, 1))")	# Name input_t (line 9)
+        self.assertEqual(str(id2type[131]), "(torch.Tensor(float64, (3, 51)), torch.Tensor(float64, (3, 51)))")	# Tuple (h_t, c_t) (line 9)
+        self.assertEqual(str(id2type[132]), "torch.Tensor(float64, (3, 51))")	# Name h_t (line 9)
+        self.assertEqual(str(id2type[134]), "torch.Tensor(float64, (3, 51))")	# Name c_t (line 9)
+        self.assertEqual(str(id2type[137]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[138]), "(torch.Tensor(float64, (3, 51)), torch.Tensor(float64, (3, 51)))")	# Tuple (h_t2, c_t2) (line 10)
+        self.assertEqual(str(id2type[139]), "torch.Tensor(float64, (3, 51))")	# Name h_t2 (line 10)
+        self.assertEqual(str(id2type[141]), "torch.Tensor(float64, (3, 51))")	# Name c_t2 (line 10)
+        self.assertEqual(str(id2type[144]), "(torch.Tensor(float64, (3, 51)), torch.Tensor(float64, (3, 51)))")	# Call self.lstm2(h_t, (h_t2, c_t2)) (line 10)
+        self.assertEqual(str(id2type[145]), "torch.Tensor(float64, (3, 51)) -> (torch.Tensor(float64, (3, 51)), torch.Tensor(float64, (3, 51))) -> (torch.Tensor(float64, (3, 51)), torch.Tensor(float64, (3, 51)))")	# Attribute self.lstm2 (line 10)
+        self.assertEqual(str(id2type[146]), "class Sequence")	# Name self (line 10)
+        self.assertEqual(str(id2type[149]), "torch.Tensor(float64, (3, 51))")	# Name h_t (line 10)
+        self.assertEqual(str(id2type[151]), "(torch.Tensor(float64, (3, 51)), torch.Tensor(float64, (3, 51)))")	# Tuple (h_t2, c_t2) (line 10)
+        self.assertEqual(str(id2type[152]), "torch.Tensor(float64, (3, 51))")	# Name h_t2 (line 10)
+        self.assertEqual(str(id2type[154]), "torch.Tensor(float64, (3, 51))")	# Name c_t2 (line 10)
+        self.assertEqual(str(id2type[157]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[158]), "torch.Tensor(float64, (3, 1))")	# Name output (line 11)
+        self.assertEqual(str(id2type[160]), "torch.Tensor(float64, (3, 1))")	# Call self.linear(h_t2) (line 11)
+        self.assertEqual(str(id2type[161]), "torch.Tensor(float64, (3, 51)) -> torch.Tensor(float64, (3, 1))")	# Attribute self.linear (line 11)
+        self.assertEqual(str(id2type[162]), "class Sequence")	# Name self (line 11)
+        self.assertEqual(str(id2type[165]), "torch.Tensor(float64, (3, 51))")	# Name h_t2 (line 11)
+        self.assertEqual(str(id2type[167]), "NoneType")	# AugAssign
+        self.assertEqual(str(id2type[168]), "torch.Tensor(float64, (3, 1)) list")	# Name outputs (line 12)
+        self.assertEqual(str(id2type[170]), "torch.Tensor(float64, (3, 1)) list -> [torch.Tensor(float64, (3, 1))] -> torch.Tensor(float64, (3, 1)) list")	# Add
+        self.assertEqual(str(id2type[171]), "[torch.Tensor(float64, (3, 1))]")	# List [output] (line 12)
+        self.assertEqual(str(id2type[172]), "torch.Tensor(float64, (3, 1))")	# Name output (line 12)
+        self.assertEqual(str(id2type[175]), "NoneType")	# For
+        self.assertEqual(str(id2type[176]), "int")	# Name i (line 13)
+        self.assertEqual(str(id2type[178]), "int list")	# Call range(future) (line 13)
+        self.assertEqual(str(id2type[179]), "int -> int list")	# Name range (line 13)
+        self.assertEqual(str(id2type[181]), "int")	# Name future (line 13)
+        self.assertEqual(str(id2type[183]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[184]), "(torch.Tensor(float64, (3, 51)), torch.Tensor(float64, (3, 51)))")	# Tuple (h_t, c_t) (line 14)
+        self.assertEqual(str(id2type[185]), "torch.Tensor(float64, (3, 51))")	# Name h_t (line 14)
+        self.assertEqual(str(id2type[187]), "torch.Tensor(float64, (3, 51))")	# Name c_t (line 14)
+        self.assertEqual(str(id2type[190]), "(torch.Tensor(float64, (3, 51)), torch.Tensor(float64, (3, 51)))")	# Call self.lstm1(output, (h_t, c_t)) (line 14)
+        self.assertEqual(str(id2type[191]), "torch.Tensor(float64, (3, 1)) -> (torch.Tensor(float64, (3, 51)), torch.Tensor(float64, (3, 51))) -> (torch.Tensor(float64, (3, 51)), torch.Tensor(float64, (3, 51)))")	# Attribute self.lstm1 (line 14)
+        self.assertEqual(str(id2type[192]), "class Sequence")	# Name self (line 14)
+        self.assertEqual(str(id2type[195]), "torch.Tensor(float64, (3, 1))")	# Name output (line 14)
+        self.assertEqual(str(id2type[197]), "(torch.Tensor(float64, (3, 51)), torch.Tensor(float64, (3, 51)))")	# Tuple (h_t, c_t) (line 14)
+        self.assertEqual(str(id2type[198]), "torch.Tensor(float64, (3, 51))")	# Name h_t (line 14)
+        self.assertEqual(str(id2type[200]), "torch.Tensor(float64, (3, 51))")	# Name c_t (line 14)
+        self.assertEqual(str(id2type[203]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[204]), "(torch.Tensor(float64, (3, 51)), torch.Tensor(float64, (3, 51)))")	# Tuple (h_t2, c_t2) (line 15)
+        self.assertEqual(str(id2type[205]), "torch.Tensor(float64, (3, 51))")	# Name h_t2 (line 15)
+        self.assertEqual(str(id2type[207]), "torch.Tensor(float64, (3, 51))")	# Name c_t2 (line 15)
+        self.assertEqual(str(id2type[210]), "(torch.Tensor(float64, (3, 51)), torch.Tensor(float64, (3, 51)))")	# Call self.lstm2(h_t, (h_t2, c_t2)) (line 15)
+        self.assertEqual(str(id2type[211]), "torch.Tensor(float64, (3, 51)) -> (torch.Tensor(float64, (3, 51)), torch.Tensor(float64, (3, 51))) -> (torch.Tensor(float64, (3, 51)), torch.Tensor(float64, (3, 51)))")	# Attribute self.lstm2 (line 15)
+        self.assertEqual(str(id2type[212]), "class Sequence")	# Name self (line 15)
+        self.assertEqual(str(id2type[215]), "torch.Tensor(float64, (3, 51))")	# Name h_t (line 15)
+        self.assertEqual(str(id2type[217]), "(torch.Tensor(float64, (3, 51)), torch.Tensor(float64, (3, 51)))")	# Tuple (h_t2, c_t2) (line 15)
+        self.assertEqual(str(id2type[218]), "torch.Tensor(float64, (3, 51))")	# Name h_t2 (line 15)
+        self.assertEqual(str(id2type[220]), "torch.Tensor(float64, (3, 51))")	# Name c_t2 (line 15)
+        self.assertEqual(str(id2type[223]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[224]), "torch.Tensor(float64, (3, 1))")	# Name output (line 16)
+        self.assertEqual(str(id2type[226]), "torch.Tensor(float64, (3, 1))")	# Call self.linear(h_t2) (line 16)
+        self.assertEqual(str(id2type[227]), "torch.Tensor(float64, (3, 51)) -> torch.Tensor(float64, (3, 1))")	# Attribute self.linear (line 16)
+        self.assertEqual(str(id2type[228]), "class Sequence")	# Name self (line 16)
+        self.assertEqual(str(id2type[231]), "torch.Tensor(float64, (3, 51))")	# Name h_t2 (line 16)
+        self.assertEqual(str(id2type[233]), "NoneType")	# AugAssign
+        self.assertEqual(str(id2type[234]), "torch.Tensor(float64, (3, 1)) list")	# Name outputs (line 17)
+        self.assertEqual(str(id2type[236]), "torch.Tensor(float64, (3, 1)) list -> [torch.Tensor(float64, (3, 1))] -> torch.Tensor(float64, (3, 1)) list")	# Add
+        self.assertEqual(str(id2type[237]), "[torch.Tensor(float64, (3, 1))]")	# List [output] (line 17)
+        self.assertEqual(str(id2type[238]), "torch.Tensor(float64, (3, 1))")	# Name output (line 17)
+        self.assertEqual(str(id2type[241]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[242]), "torch.Tensor(float64, (3, None))")	# Name outputs (line 19)
+        self.assertEqual(str(id2type[244]), "torch.Tensor(float64, (3, None))")	# Call torch.stack(outputs, dim=1).squeeze(dim=2) (line 19)
+        self.assertEqual(str(id2type[245]), "(no argument) -> torch.Tensor(float64, (3, None))")	# Attribute torch.stack(outputs, dim=1).squeeze (line 19)
+        self.assertEqual(str(id2type[246]), "torch.Tensor(float64, (3, None, 1))")	# Call torch.stack(outputs, dim=1) (line 19)
+        self.assertEqual(str(id2type[247]), "torch.Tensor(float64, (3, 1)) list -> torch.Tensor(float64, (3, None, 1))")	# Attribute torch.stack (line 19)
+        self.assertEqual(str(id2type[251]), "torch.Tensor(float64, (3, 1)) list")	# Name outputs (line 19)
+        self.assertEqual(str(id2type[254]), "int")	# Constant 1 (line 19)
+        self.assertEqual(str(id2type[257]), "int")	# Constant 2 (line 19)
+        self.assertEqual(str(id2type[258]), "torch.Tensor(float64, (3, None))")	# Return
+        self.assertEqual(str(id2type[259]), "torch.Tensor(float64, (3, None))")	# Name outputs (line 20)
+
+
+def main():
+    unittest.main()
+
+if __name__ == '__main__':
+    main()

--- a/tests/elichika_typing/pytorch/examples/transformer_net.py
+++ b/tests/elichika_typing/pytorch/examples/transformer_net.py
@@ -1,0 +1,560 @@
+import torch
+import torch.nn as nn
+import unittest
+
+from chainer_compiler.elichika.testtools import generate_id2type_from_forward
+from chainer_compiler.elichika.testtools import type_inference_tools
+
+from testcases.pytorch.examples.transformer_net import gen_TransformerNet_test
+
+
+class TestTransformerNet(unittest.TestCase):
+    def test_TransformerNet(self):
+        type_inference_tools.reset_state()
+
+        model, forward_args = gen_TransformerNet_test()
+        id2type = generate_id2type_from_forward(model, forward_args)
+
+        self.assertEqual(str(id2type[1]), "class TransformerNet -> torch.Tensor(float32, (5, 3, 16, 16)) -> torch.Tensor(float32, (5, 3, None, None))")	# FunctionDef forward (line 1)
+        self.assertEqual(str(id2type[7]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[8]), "torch.Tensor(float32, (5, 32, 16, 16))")	# Name y (line 2)
+        self.assertEqual(str(id2type[10]), "torch.Tensor(float32, (5, 32, 16, 16))")	# Call self.relu(self.in1(self.conv1(X))) (line 2)
+        self.assertEqual(str(id2type[11]), "torch.Tensor(float32, (5, 32, 16, 16)) -> torch.Tensor(float32, (5, 32, 16, 16))")	# Attribute self.relu (line 2)
+        self.assertEqual(str(id2type[12]), "class TransformerNet")	# Name self (line 2)
+        self.assertEqual(str(id2type[15]), "torch.Tensor(float32, (5, 32, 16, 16))")	# Call self.in1(self.conv1(X)) (line 2)
+        self.assertEqual(str(id2type[16]), "torch.Tensor(float32, (5, 32, 16, 16)) -> torch.Tensor(float32, (5, 32, 16, 16))")	# Attribute self.in1 (line 2)
+        self.assertEqual(str(id2type[17]), "class TransformerNet")	# Name self (line 2)
+        self.assertEqual(str(id2type[20]), "torch.Tensor(float32, (5, 32, 16, 16))")	# Call self.conv1(X) (line 2)
+        self.assertEqual(str(id2type[21]), "torch.Tensor(float32, (5, 3, 16, 16)) -> torch.Tensor(float32, (5, 32, 16, 16))")	# Attribute self.conv1 (line 2)
+        self.assertEqual(str(id2type[22]), "class TransformerNet")	# Name self (line 2)
+        self.assertEqual(str(id2type[25]), "torch.Tensor(float32, (5, 3, 16, 16))")	# Name X (line 2)
+        self.assertEqual(str(id2type[27]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[28]), "torch.Tensor(float32, (5, 64, 8, 8))")	# Name y (line 3)
+        self.assertEqual(str(id2type[30]), "torch.Tensor(float32, (5, 64, 8, 8))")	# Call self.relu(self.in2(self.conv2(y))) (line 3)
+        self.assertEqual(str(id2type[31]), "torch.Tensor(float32, (5, 64, 8, 8)) -> torch.Tensor(float32, (5, 64, 8, 8))")	# Attribute self.relu (line 3)
+        self.assertEqual(str(id2type[32]), "class TransformerNet")	# Name self (line 3)
+        self.assertEqual(str(id2type[35]), "torch.Tensor(float32, (5, 64, 8, 8))")	# Call self.in2(self.conv2(y)) (line 3)
+        self.assertEqual(str(id2type[36]), "torch.Tensor(float32, (5, 64, 8, 8)) -> torch.Tensor(float32, (5, 64, 8, 8))")	# Attribute self.in2 (line 3)
+        self.assertEqual(str(id2type[37]), "class TransformerNet")	# Name self (line 3)
+        self.assertEqual(str(id2type[40]), "torch.Tensor(float32, (5, 64, 8, 8))")	# Call self.conv2(y) (line 3)
+        self.assertEqual(str(id2type[41]), "torch.Tensor(float32, (5, 32, 16, 16)) -> torch.Tensor(float32, (5, 64, 8, 8))")	# Attribute self.conv2 (line 3)
+        self.assertEqual(str(id2type[42]), "class TransformerNet")	# Name self (line 3)
+        self.assertEqual(str(id2type[45]), "torch.Tensor(float32, (5, 32, 16, 16))")	# Name y (line 3)
+        self.assertEqual(str(id2type[47]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[48]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name y (line 4)
+        self.assertEqual(str(id2type[50]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Call self.relu(self.in3(self.conv3(y))) (line 4)
+        self.assertEqual(str(id2type[51]), "torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, 4, 4))")	# Attribute self.relu (line 4)
+        self.assertEqual(str(id2type[52]), "class TransformerNet")	# Name self (line 4)
+        self.assertEqual(str(id2type[55]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Call self.in3(self.conv3(y)) (line 4)
+        self.assertEqual(str(id2type[56]), "torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, 4, 4))")	# Attribute self.in3 (line 4)
+        self.assertEqual(str(id2type[57]), "class TransformerNet")	# Name self (line 4)
+        self.assertEqual(str(id2type[60]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Call self.conv3(y) (line 4)
+        self.assertEqual(str(id2type[61]), "torch.Tensor(float32, (5, 64, 8, 8)) -> torch.Tensor(float32, (5, 128, 4, 4))")	# Attribute self.conv3 (line 4)
+        self.assertEqual(str(id2type[62]), "class TransformerNet")	# Name self (line 4)
+        self.assertEqual(str(id2type[65]), "torch.Tensor(float32, (5, 64, 8, 8))")	# Name y (line 4)
+        self.assertEqual(str(id2type[67]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[68]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name y (line 5)
+        self.assertEqual(str(id2type[70]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Call self.res1(y) (line 5)
+        self.assertEqual(str(id2type[71]), "torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, 4, 4))")	# Attribute self.res1 (line 5)
+        self.assertEqual(str(id2type[72]), "class TransformerNet")	# Name self (line 5)
+        self.assertEqual(str(id2type[75]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name y (line 5)
+        self.assertEqual(str(id2type[77]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[78]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name y (line 6)
+        self.assertEqual(str(id2type[80]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Call self.res2(y) (line 6)
+        self.assertEqual(str(id2type[81]), "torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, 4, 4))")	# Attribute self.res2 (line 6)
+        self.assertEqual(str(id2type[82]), "class TransformerNet")	# Name self (line 6)
+        self.assertEqual(str(id2type[85]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name y (line 6)
+        self.assertEqual(str(id2type[87]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[88]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name y (line 7)
+        self.assertEqual(str(id2type[90]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Call self.res3(y) (line 7)
+        self.assertEqual(str(id2type[91]), "torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, 4, 4))")	# Attribute self.res3 (line 7)
+        self.assertEqual(str(id2type[92]), "class TransformerNet")	# Name self (line 7)
+        self.assertEqual(str(id2type[95]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name y (line 7)
+        self.assertEqual(str(id2type[97]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[98]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name y (line 8)
+        self.assertEqual(str(id2type[100]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Call self.res4(y) (line 8)
+        self.assertEqual(str(id2type[101]), "torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, 4, 4))")	# Attribute self.res4 (line 8)
+        self.assertEqual(str(id2type[102]), "class TransformerNet")	# Name self (line 8)
+        self.assertEqual(str(id2type[105]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name y (line 8)
+        self.assertEqual(str(id2type[107]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[108]), "torch.Tensor(float32, (5, 128, None, None))")	# Name y (line 9)
+        self.assertEqual(str(id2type[110]), "torch.Tensor(float32, (5, 128, None, None))")	# Call self.res5(y) (line 9)
+        self.assertEqual(str(id2type[111]), "torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, None, None))")	# Attribute self.res5 (line 9)
+        self.assertEqual(str(id2type[112]), "class TransformerNet")	# Name self (line 9)
+        self.assertEqual(str(id2type[115]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name y (line 9)
+        self.assertEqual(str(id2type[117]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[118]), "torch.Tensor(float32, (5, 64, None, None))")	# Name y (line 10)
+        self.assertEqual(str(id2type[120]), "torch.Tensor(float32, (5, 64, None, None))")	# Call self.relu(self.in4(self.deconv1(y))) (line 10)
+        self.assertEqual(str(id2type[121]), "torch.Tensor(float32, (5, 64, None, None)) -> torch.Tensor(float32, (5, 64, None, None))")	# Attribute self.relu (line 10)
+        self.assertEqual(str(id2type[122]), "class TransformerNet")	# Name self (line 10)
+        self.assertEqual(str(id2type[125]), "torch.Tensor(float32, (5, 64, None, None))")	# Call self.in4(self.deconv1(y)) (line 10)
+        self.assertEqual(str(id2type[126]), "torch.Tensor(float32, (5, 64, None, None)) -> torch.Tensor(float32, (5, 64, None, None))")	# Attribute self.in4 (line 10)
+        self.assertEqual(str(id2type[127]), "class TransformerNet")	# Name self (line 10)
+        self.assertEqual(str(id2type[130]), "torch.Tensor(float32, (5, 64, None, None))")	# Call self.deconv1(y) (line 10)
+        self.assertEqual(str(id2type[131]), "torch.Tensor(float32, (5, 128, None, None)) -> torch.Tensor(float32, (5, 64, None, None))")	# Attribute self.deconv1 (line 10)
+        self.assertEqual(str(id2type[132]), "class TransformerNet")	# Name self (line 10)
+        self.assertEqual(str(id2type[135]), "torch.Tensor(float32, (5, 128, None, None))")	# Name y (line 10)
+        self.assertEqual(str(id2type[137]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[138]), "torch.Tensor(float32, (5, 32, None, None))")	# Name y (line 11)
+        self.assertEqual(str(id2type[140]), "torch.Tensor(float32, (5, 32, None, None))")	# Call self.relu(self.in5(self.deconv2(y))) (line 11)
+        self.assertEqual(str(id2type[141]), "torch.Tensor(float32, (5, 32, None, None)) -> torch.Tensor(float32, (5, 32, None, None))")	# Attribute self.relu (line 11)
+        self.assertEqual(str(id2type[142]), "class TransformerNet")	# Name self (line 11)
+        self.assertEqual(str(id2type[145]), "torch.Tensor(float32, (5, 32, None, None))")	# Call self.in5(self.deconv2(y)) (line 11)
+        self.assertEqual(str(id2type[146]), "torch.Tensor(float32, (5, 32, None, None)) -> torch.Tensor(float32, (5, 32, None, None))")	# Attribute self.in5 (line 11)
+        self.assertEqual(str(id2type[147]), "class TransformerNet")	# Name self (line 11)
+        self.assertEqual(str(id2type[150]), "torch.Tensor(float32, (5, 32, None, None))")	# Call self.deconv2(y) (line 11)
+        self.assertEqual(str(id2type[151]), "torch.Tensor(float32, (5, 64, None, None)) -> torch.Tensor(float32, (5, 32, None, None))")	# Attribute self.deconv2 (line 11)
+        self.assertEqual(str(id2type[152]), "class TransformerNet")	# Name self (line 11)
+        self.assertEqual(str(id2type[155]), "torch.Tensor(float32, (5, 64, None, None))")	# Name y (line 11)
+        self.assertEqual(str(id2type[157]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[158]), "torch.Tensor(float32, (5, 3, None, None))")	# Name y (line 12)
+        self.assertEqual(str(id2type[160]), "torch.Tensor(float32, (5, 3, None, None))")	# Call self.deconv3(y) (line 12)
+        self.assertEqual(str(id2type[161]), "torch.Tensor(float32, (5, 32, None, None)) -> torch.Tensor(float32, (5, 3, None, None))")	# Attribute self.deconv3 (line 12)
+        self.assertEqual(str(id2type[162]), "class TransformerNet")	# Name self (line 12)
+        self.assertEqual(str(id2type[165]), "torch.Tensor(float32, (5, 32, None, None))")	# Name y (line 12)
+        self.assertEqual(str(id2type[167]), "torch.Tensor(float32, (5, 3, None, None))")	# Return
+        self.assertEqual(str(id2type[168]), "torch.Tensor(float32, (5, 3, None, None))")	# Name y (line 13)
+        self.assertEqual(str(id2type[170]), "class ConvLayer -> torch.Tensor(float32, (5, 3, 16, 16)) -> torch.Tensor(float32, (5, 32, 16, 16))")	# FunctionDef forward (line 1)
+        self.assertEqual(str(id2type[176]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[177]), "torch.Tensor(float32, (5, 3, 24, 24))")	# Name out (line 2)
+        self.assertEqual(str(id2type[179]), "torch.Tensor(float32, (5, 3, 24, 24))")	# Call self.reflection_pad(x) (line 2)
+        self.assertEqual(str(id2type[180]), "torch.Tensor(float32, (5, 3, 16, 16)) -> torch.Tensor(float32, (5, 3, 24, 24))")	# Attribute self.reflection_pad (line 2)
+        self.assertEqual(str(id2type[181]), "class ConvLayer")	# Name self (line 2)
+        self.assertEqual(str(id2type[184]), "torch.Tensor(float32, (5, 3, 16, 16))")	# Name x (line 2)
+        self.assertEqual(str(id2type[186]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[187]), "torch.Tensor(float32, (5, 32, 16, 16))")	# Name out (line 3)
+        self.assertEqual(str(id2type[189]), "torch.Tensor(float32, (5, 32, 16, 16))")	# Call self.conv2d(out) (line 3)
+        self.assertEqual(str(id2type[190]), "torch.Tensor(float32, (5, 3, 24, 24)) -> torch.Tensor(float32, (5, 32, 16, 16))")	# Attribute self.conv2d (line 3)
+        self.assertEqual(str(id2type[191]), "class ConvLayer")	# Name self (line 3)
+        self.assertEqual(str(id2type[194]), "torch.Tensor(float32, (5, 3, 24, 24))")	# Name out (line 3)
+        self.assertEqual(str(id2type[196]), "torch.Tensor(float32, (5, 32, 16, 16))")	# Return
+        self.assertEqual(str(id2type[197]), "torch.Tensor(float32, (5, 32, 16, 16))")	# Name out (line 4)
+        self.assertEqual(str(id2type[199]), "class ConvLayer -> torch.Tensor(float32, (5, 32, 16, 16)) -> torch.Tensor(float32, (5, 64, 8, 8))")	# FunctionDef forward (line 1)
+        self.assertEqual(str(id2type[205]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[206]), "torch.Tensor(float32, (5, 32, 18, 18))")	# Name out (line 2)
+        self.assertEqual(str(id2type[208]), "torch.Tensor(float32, (5, 32, 18, 18))")	# Call self.reflection_pad(x) (line 2)
+        self.assertEqual(str(id2type[209]), "torch.Tensor(float32, (5, 32, 16, 16)) -> torch.Tensor(float32, (5, 32, 18, 18))")	# Attribute self.reflection_pad (line 2)
+        self.assertEqual(str(id2type[210]), "class ConvLayer")	# Name self (line 2)
+        self.assertEqual(str(id2type[213]), "torch.Tensor(float32, (5, 32, 16, 16))")	# Name x (line 2)
+        self.assertEqual(str(id2type[215]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[216]), "torch.Tensor(float32, (5, 64, 8, 8))")	# Name out (line 3)
+        self.assertEqual(str(id2type[218]), "torch.Tensor(float32, (5, 64, 8, 8))")	# Call self.conv2d(out) (line 3)
+        self.assertEqual(str(id2type[219]), "torch.Tensor(float32, (5, 32, 18, 18)) -> torch.Tensor(float32, (5, 64, 8, 8))")	# Attribute self.conv2d (line 3)
+        self.assertEqual(str(id2type[220]), "class ConvLayer")	# Name self (line 3)
+        self.assertEqual(str(id2type[223]), "torch.Tensor(float32, (5, 32, 18, 18))")	# Name out (line 3)
+        self.assertEqual(str(id2type[225]), "torch.Tensor(float32, (5, 64, 8, 8))")	# Return
+        self.assertEqual(str(id2type[226]), "torch.Tensor(float32, (5, 64, 8, 8))")	# Name out (line 4)
+        self.assertEqual(str(id2type[228]), "class ConvLayer -> torch.Tensor(float32, (5, 64, 8, 8)) -> torch.Tensor(float32, (5, 128, 4, 4))")	# FunctionDef forward (line 1)
+        self.assertEqual(str(id2type[234]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[235]), "torch.Tensor(float32, (5, 64, 10, 10))")	# Name out (line 2)
+        self.assertEqual(str(id2type[237]), "torch.Tensor(float32, (5, 64, 10, 10))")	# Call self.reflection_pad(x) (line 2)
+        self.assertEqual(str(id2type[238]), "torch.Tensor(float32, (5, 64, 8, 8)) -> torch.Tensor(float32, (5, 64, 10, 10))")	# Attribute self.reflection_pad (line 2)
+        self.assertEqual(str(id2type[239]), "class ConvLayer")	# Name self (line 2)
+        self.assertEqual(str(id2type[242]), "torch.Tensor(float32, (5, 64, 8, 8))")	# Name x (line 2)
+        self.assertEqual(str(id2type[244]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[245]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name out (line 3)
+        self.assertEqual(str(id2type[247]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Call self.conv2d(out) (line 3)
+        self.assertEqual(str(id2type[248]), "torch.Tensor(float32, (5, 64, 10, 10)) -> torch.Tensor(float32, (5, 128, 4, 4))")	# Attribute self.conv2d (line 3)
+        self.assertEqual(str(id2type[249]), "class ConvLayer")	# Name self (line 3)
+        self.assertEqual(str(id2type[252]), "torch.Tensor(float32, (5, 64, 10, 10))")	# Name out (line 3)
+        self.assertEqual(str(id2type[254]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Return
+        self.assertEqual(str(id2type[255]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name out (line 4)
+        self.assertEqual(str(id2type[257]), "class ResidualBlock -> torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, 4, 4))")	# FunctionDef forward (line 1)
+        self.assertEqual(str(id2type[263]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[264]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name residual (line 2)
+        self.assertEqual(str(id2type[266]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name x (line 2)
+        self.assertEqual(str(id2type[268]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[269]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name out (line 3)
+        self.assertEqual(str(id2type[271]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Call self.relu(self.in1(self.conv1(x))) (line 3)
+        self.assertEqual(str(id2type[272]), "torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, 4, 4))")	# Attribute self.relu (line 3)
+        self.assertEqual(str(id2type[273]), "class ResidualBlock")	# Name self (line 3)
+        self.assertEqual(str(id2type[276]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Call self.in1(self.conv1(x)) (line 3)
+        self.assertEqual(str(id2type[277]), "torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, 4, 4))")	# Attribute self.in1 (line 3)
+        self.assertEqual(str(id2type[278]), "class ResidualBlock")	# Name self (line 3)
+        self.assertEqual(str(id2type[281]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Call self.conv1(x) (line 3)
+        self.assertEqual(str(id2type[282]), "torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, 4, 4))")	# Attribute self.conv1 (line 3)
+        self.assertEqual(str(id2type[283]), "class ResidualBlock")	# Name self (line 3)
+        self.assertEqual(str(id2type[286]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name x (line 3)
+        self.assertEqual(str(id2type[288]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[289]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name out (line 4)
+        self.assertEqual(str(id2type[291]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Call self.in2(self.conv2(out)) (line 4)
+        self.assertEqual(str(id2type[292]), "torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, 4, 4))")	# Attribute self.in2 (line 4)
+        self.assertEqual(str(id2type[293]), "class ResidualBlock")	# Name self (line 4)
+        self.assertEqual(str(id2type[296]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Call self.conv2(out) (line 4)
+        self.assertEqual(str(id2type[297]), "torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, 4, 4))")	# Attribute self.conv2 (line 4)
+        self.assertEqual(str(id2type[298]), "class ResidualBlock")	# Name self (line 4)
+        self.assertEqual(str(id2type[301]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name out (line 4)
+        self.assertEqual(str(id2type[303]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[304]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name out (line 5)
+        self.assertEqual(str(id2type[306]), "torch.Tensor(float32, (5, 128, 4, 4))")	# BinOp out + residual (line 5)
+        self.assertEqual(str(id2type[307]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name out (line 5)
+        self.assertEqual(str(id2type[309]), "torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, 4, 4))")	# Add
+        self.assertEqual(str(id2type[310]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name residual (line 5)
+        self.assertEqual(str(id2type[312]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Return
+        self.assertEqual(str(id2type[313]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name out (line 6)
+        self.assertEqual(str(id2type[315]), "class ConvLayer -> torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, 4, 4))")	# FunctionDef forward (line 1)
+        self.assertEqual(str(id2type[321]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[322]), "torch.Tensor(float32, (5, 128, 6, 6))")	# Name out (line 2)
+        self.assertEqual(str(id2type[324]), "torch.Tensor(float32, (5, 128, 6, 6))")	# Call self.reflection_pad(x) (line 2)
+        self.assertEqual(str(id2type[325]), "torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, 6, 6))")	# Attribute self.reflection_pad (line 2)
+        self.assertEqual(str(id2type[326]), "class ConvLayer")	# Name self (line 2)
+        self.assertEqual(str(id2type[329]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name x (line 2)
+        self.assertEqual(str(id2type[331]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[332]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name out (line 3)
+        self.assertEqual(str(id2type[334]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Call self.conv2d(out) (line 3)
+        self.assertEqual(str(id2type[335]), "torch.Tensor(float32, (5, 128, 6, 6)) -> torch.Tensor(float32, (5, 128, 4, 4))")	# Attribute self.conv2d (line 3)
+        self.assertEqual(str(id2type[336]), "class ConvLayer")	# Name self (line 3)
+        self.assertEqual(str(id2type[339]), "torch.Tensor(float32, (5, 128, 6, 6))")	# Name out (line 3)
+        self.assertEqual(str(id2type[341]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Return
+        self.assertEqual(str(id2type[342]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name out (line 4)
+        self.assertEqual(str(id2type[344]), "class ConvLayer -> torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, 4, 4))")	# FunctionDef forward (line 1)
+        self.assertEqual(str(id2type[350]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[351]), "torch.Tensor(float32, (5, 128, 6, 6))")	# Name out (line 2)
+        self.assertEqual(str(id2type[353]), "torch.Tensor(float32, (5, 128, 6, 6))")	# Call self.reflection_pad(x) (line 2)
+        self.assertEqual(str(id2type[354]), "torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, 6, 6))")	# Attribute self.reflection_pad (line 2)
+        self.assertEqual(str(id2type[355]), "class ConvLayer")	# Name self (line 2)
+        self.assertEqual(str(id2type[358]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name x (line 2)
+        self.assertEqual(str(id2type[360]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[361]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name out (line 3)
+        self.assertEqual(str(id2type[363]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Call self.conv2d(out) (line 3)
+        self.assertEqual(str(id2type[364]), "torch.Tensor(float32, (5, 128, 6, 6)) -> torch.Tensor(float32, (5, 128, 4, 4))")	# Attribute self.conv2d (line 3)
+        self.assertEqual(str(id2type[365]), "class ConvLayer")	# Name self (line 3)
+        self.assertEqual(str(id2type[368]), "torch.Tensor(float32, (5, 128, 6, 6))")	# Name out (line 3)
+        self.assertEqual(str(id2type[370]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Return
+        self.assertEqual(str(id2type[371]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name out (line 4)
+        self.assertEqual(str(id2type[373]), "class ResidualBlock -> torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, 4, 4))")	# FunctionDef forward (line 1)
+        self.assertEqual(str(id2type[379]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[380]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name residual (line 2)
+        self.assertEqual(str(id2type[382]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name x (line 2)
+        self.assertEqual(str(id2type[384]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[385]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name out (line 3)
+        self.assertEqual(str(id2type[387]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Call self.relu(self.in1(self.conv1(x))) (line 3)
+        self.assertEqual(str(id2type[388]), "torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, 4, 4))")	# Attribute self.relu (line 3)
+        self.assertEqual(str(id2type[389]), "class ResidualBlock")	# Name self (line 3)
+        self.assertEqual(str(id2type[392]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Call self.in1(self.conv1(x)) (line 3)
+        self.assertEqual(str(id2type[393]), "torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, 4, 4))")	# Attribute self.in1 (line 3)
+        self.assertEqual(str(id2type[394]), "class ResidualBlock")	# Name self (line 3)
+        self.assertEqual(str(id2type[397]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Call self.conv1(x) (line 3)
+        self.assertEqual(str(id2type[398]), "torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, 4, 4))")	# Attribute self.conv1 (line 3)
+        self.assertEqual(str(id2type[399]), "class ResidualBlock")	# Name self (line 3)
+        self.assertEqual(str(id2type[402]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name x (line 3)
+        self.assertEqual(str(id2type[404]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[405]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name out (line 4)
+        self.assertEqual(str(id2type[407]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Call self.in2(self.conv2(out)) (line 4)
+        self.assertEqual(str(id2type[408]), "torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, 4, 4))")	# Attribute self.in2 (line 4)
+        self.assertEqual(str(id2type[409]), "class ResidualBlock")	# Name self (line 4)
+        self.assertEqual(str(id2type[412]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Call self.conv2(out) (line 4)
+        self.assertEqual(str(id2type[413]), "torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, 4, 4))")	# Attribute self.conv2 (line 4)
+        self.assertEqual(str(id2type[414]), "class ResidualBlock")	# Name self (line 4)
+        self.assertEqual(str(id2type[417]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name out (line 4)
+        self.assertEqual(str(id2type[419]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[420]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name out (line 5)
+        self.assertEqual(str(id2type[422]), "torch.Tensor(float32, (5, 128, 4, 4))")	# BinOp out + residual (line 5)
+        self.assertEqual(str(id2type[423]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name out (line 5)
+        self.assertEqual(str(id2type[425]), "torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, 4, 4))")	# Add
+        self.assertEqual(str(id2type[426]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name residual (line 5)
+        self.assertEqual(str(id2type[428]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Return
+        self.assertEqual(str(id2type[429]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name out (line 6)
+        self.assertEqual(str(id2type[431]), "class ConvLayer -> torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, 4, 4))")	# FunctionDef forward (line 1)
+        self.assertEqual(str(id2type[437]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[438]), "torch.Tensor(float32, (5, 128, 6, 6))")	# Name out (line 2)
+        self.assertEqual(str(id2type[440]), "torch.Tensor(float32, (5, 128, 6, 6))")	# Call self.reflection_pad(x) (line 2)
+        self.assertEqual(str(id2type[441]), "torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, 6, 6))")	# Attribute self.reflection_pad (line 2)
+        self.assertEqual(str(id2type[442]), "class ConvLayer")	# Name self (line 2)
+        self.assertEqual(str(id2type[445]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name x (line 2)
+        self.assertEqual(str(id2type[447]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[448]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name out (line 3)
+        self.assertEqual(str(id2type[450]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Call self.conv2d(out) (line 3)
+        self.assertEqual(str(id2type[451]), "torch.Tensor(float32, (5, 128, 6, 6)) -> torch.Tensor(float32, (5, 128, 4, 4))")	# Attribute self.conv2d (line 3)
+        self.assertEqual(str(id2type[452]), "class ConvLayer")	# Name self (line 3)
+        self.assertEqual(str(id2type[455]), "torch.Tensor(float32, (5, 128, 6, 6))")	# Name out (line 3)
+        self.assertEqual(str(id2type[457]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Return
+        self.assertEqual(str(id2type[458]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name out (line 4)
+        self.assertEqual(str(id2type[460]), "class ConvLayer -> torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, 4, 4))")	# FunctionDef forward (line 1)
+        self.assertEqual(str(id2type[466]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[467]), "torch.Tensor(float32, (5, 128, 6, 6))")	# Name out (line 2)
+        self.assertEqual(str(id2type[469]), "torch.Tensor(float32, (5, 128, 6, 6))")	# Call self.reflection_pad(x) (line 2)
+        self.assertEqual(str(id2type[470]), "torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, 6, 6))")	# Attribute self.reflection_pad (line 2)
+        self.assertEqual(str(id2type[471]), "class ConvLayer")	# Name self (line 2)
+        self.assertEqual(str(id2type[474]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name x (line 2)
+        self.assertEqual(str(id2type[476]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[477]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name out (line 3)
+        self.assertEqual(str(id2type[479]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Call self.conv2d(out) (line 3)
+        self.assertEqual(str(id2type[480]), "torch.Tensor(float32, (5, 128, 6, 6)) -> torch.Tensor(float32, (5, 128, 4, 4))")	# Attribute self.conv2d (line 3)
+        self.assertEqual(str(id2type[481]), "class ConvLayer")	# Name self (line 3)
+        self.assertEqual(str(id2type[484]), "torch.Tensor(float32, (5, 128, 6, 6))")	# Name out (line 3)
+        self.assertEqual(str(id2type[486]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Return
+        self.assertEqual(str(id2type[487]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name out (line 4)
+        self.assertEqual(str(id2type[489]), "class ResidualBlock -> torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, 4, 4))")	# FunctionDef forward (line 1)
+        self.assertEqual(str(id2type[495]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[496]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name residual (line 2)
+        self.assertEqual(str(id2type[498]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name x (line 2)
+        self.assertEqual(str(id2type[500]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[501]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name out (line 3)
+        self.assertEqual(str(id2type[503]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Call self.relu(self.in1(self.conv1(x))) (line 3)
+        self.assertEqual(str(id2type[504]), "torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, 4, 4))")	# Attribute self.relu (line 3)
+        self.assertEqual(str(id2type[505]), "class ResidualBlock")	# Name self (line 3)
+        self.assertEqual(str(id2type[508]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Call self.in1(self.conv1(x)) (line 3)
+        self.assertEqual(str(id2type[509]), "torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, 4, 4))")	# Attribute self.in1 (line 3)
+        self.assertEqual(str(id2type[510]), "class ResidualBlock")	# Name self (line 3)
+        self.assertEqual(str(id2type[513]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Call self.conv1(x) (line 3)
+        self.assertEqual(str(id2type[514]), "torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, 4, 4))")	# Attribute self.conv1 (line 3)
+        self.assertEqual(str(id2type[515]), "class ResidualBlock")	# Name self (line 3)
+        self.assertEqual(str(id2type[518]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name x (line 3)
+        self.assertEqual(str(id2type[520]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[521]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name out (line 4)
+        self.assertEqual(str(id2type[523]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Call self.in2(self.conv2(out)) (line 4)
+        self.assertEqual(str(id2type[524]), "torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, 4, 4))")	# Attribute self.in2 (line 4)
+        self.assertEqual(str(id2type[525]), "class ResidualBlock")	# Name self (line 4)
+        self.assertEqual(str(id2type[528]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Call self.conv2(out) (line 4)
+        self.assertEqual(str(id2type[529]), "torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, 4, 4))")	# Attribute self.conv2 (line 4)
+        self.assertEqual(str(id2type[530]), "class ResidualBlock")	# Name self (line 4)
+        self.assertEqual(str(id2type[533]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name out (line 4)
+        self.assertEqual(str(id2type[535]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[536]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name out (line 5)
+        self.assertEqual(str(id2type[538]), "torch.Tensor(float32, (5, 128, 4, 4))")	# BinOp out + residual (line 5)
+        self.assertEqual(str(id2type[539]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name out (line 5)
+        self.assertEqual(str(id2type[541]), "torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, 4, 4))")	# Add
+        self.assertEqual(str(id2type[542]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name residual (line 5)
+        self.assertEqual(str(id2type[544]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Return
+        self.assertEqual(str(id2type[545]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name out (line 6)
+        self.assertEqual(str(id2type[547]), "class ConvLayer -> torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, 4, 4))")	# FunctionDef forward (line 1)
+        self.assertEqual(str(id2type[553]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[554]), "torch.Tensor(float32, (5, 128, 6, 6))")	# Name out (line 2)
+        self.assertEqual(str(id2type[556]), "torch.Tensor(float32, (5, 128, 6, 6))")	# Call self.reflection_pad(x) (line 2)
+        self.assertEqual(str(id2type[557]), "torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, 6, 6))")	# Attribute self.reflection_pad (line 2)
+        self.assertEqual(str(id2type[558]), "class ConvLayer")	# Name self (line 2)
+        self.assertEqual(str(id2type[561]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name x (line 2)
+        self.assertEqual(str(id2type[563]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[564]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name out (line 3)
+        self.assertEqual(str(id2type[566]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Call self.conv2d(out) (line 3)
+        self.assertEqual(str(id2type[567]), "torch.Tensor(float32, (5, 128, 6, 6)) -> torch.Tensor(float32, (5, 128, 4, 4))")	# Attribute self.conv2d (line 3)
+        self.assertEqual(str(id2type[568]), "class ConvLayer")	# Name self (line 3)
+        self.assertEqual(str(id2type[571]), "torch.Tensor(float32, (5, 128, 6, 6))")	# Name out (line 3)
+        self.assertEqual(str(id2type[573]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Return
+        self.assertEqual(str(id2type[574]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name out (line 4)
+        self.assertEqual(str(id2type[576]), "class ConvLayer -> torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, 4, 4))")	# FunctionDef forward (line 1)
+        self.assertEqual(str(id2type[582]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[583]), "torch.Tensor(float32, (5, 128, 6, 6))")	# Name out (line 2)
+        self.assertEqual(str(id2type[585]), "torch.Tensor(float32, (5, 128, 6, 6))")	# Call self.reflection_pad(x) (line 2)
+        self.assertEqual(str(id2type[586]), "torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, 6, 6))")	# Attribute self.reflection_pad (line 2)
+        self.assertEqual(str(id2type[587]), "class ConvLayer")	# Name self (line 2)
+        self.assertEqual(str(id2type[590]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name x (line 2)
+        self.assertEqual(str(id2type[592]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[593]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name out (line 3)
+        self.assertEqual(str(id2type[595]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Call self.conv2d(out) (line 3)
+        self.assertEqual(str(id2type[596]), "torch.Tensor(float32, (5, 128, 6, 6)) -> torch.Tensor(float32, (5, 128, 4, 4))")	# Attribute self.conv2d (line 3)
+        self.assertEqual(str(id2type[597]), "class ConvLayer")	# Name self (line 3)
+        self.assertEqual(str(id2type[600]), "torch.Tensor(float32, (5, 128, 6, 6))")	# Name out (line 3)
+        self.assertEqual(str(id2type[602]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Return
+        self.assertEqual(str(id2type[603]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name out (line 4)
+        self.assertEqual(str(id2type[605]), "class ResidualBlock -> torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, 4, 4))")	# FunctionDef forward (line 1)
+        self.assertEqual(str(id2type[611]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[612]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name residual (line 2)
+        self.assertEqual(str(id2type[614]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name x (line 2)
+        self.assertEqual(str(id2type[616]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[617]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name out (line 3)
+        self.assertEqual(str(id2type[619]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Call self.relu(self.in1(self.conv1(x))) (line 3)
+        self.assertEqual(str(id2type[620]), "torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, 4, 4))")	# Attribute self.relu (line 3)
+        self.assertEqual(str(id2type[621]), "class ResidualBlock")	# Name self (line 3)
+        self.assertEqual(str(id2type[624]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Call self.in1(self.conv1(x)) (line 3)
+        self.assertEqual(str(id2type[625]), "torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, 4, 4))")	# Attribute self.in1 (line 3)
+        self.assertEqual(str(id2type[626]), "class ResidualBlock")	# Name self (line 3)
+        self.assertEqual(str(id2type[629]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Call self.conv1(x) (line 3)
+        self.assertEqual(str(id2type[630]), "torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, 4, 4))")	# Attribute self.conv1 (line 3)
+        self.assertEqual(str(id2type[631]), "class ResidualBlock")	# Name self (line 3)
+        self.assertEqual(str(id2type[634]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name x (line 3)
+        self.assertEqual(str(id2type[636]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[637]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name out (line 4)
+        self.assertEqual(str(id2type[639]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Call self.in2(self.conv2(out)) (line 4)
+        self.assertEqual(str(id2type[640]), "torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, 4, 4))")	# Attribute self.in2 (line 4)
+        self.assertEqual(str(id2type[641]), "class ResidualBlock")	# Name self (line 4)
+        self.assertEqual(str(id2type[644]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Call self.conv2(out) (line 4)
+        self.assertEqual(str(id2type[645]), "torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, 4, 4))")	# Attribute self.conv2 (line 4)
+        self.assertEqual(str(id2type[646]), "class ResidualBlock")	# Name self (line 4)
+        self.assertEqual(str(id2type[649]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name out (line 4)
+        self.assertEqual(str(id2type[651]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[652]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name out (line 5)
+        self.assertEqual(str(id2type[654]), "torch.Tensor(float32, (5, 128, 4, 4))")	# BinOp out + residual (line 5)
+        self.assertEqual(str(id2type[655]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name out (line 5)
+        self.assertEqual(str(id2type[657]), "torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, 4, 4))")	# Add
+        self.assertEqual(str(id2type[658]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name residual (line 5)
+        self.assertEqual(str(id2type[660]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Return
+        self.assertEqual(str(id2type[661]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name out (line 6)
+        self.assertEqual(str(id2type[663]), "class ConvLayer -> torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, 4, 4))")	# FunctionDef forward (line 1)
+        self.assertEqual(str(id2type[669]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[670]), "torch.Tensor(float32, (5, 128, 6, 6))")	# Name out (line 2)
+        self.assertEqual(str(id2type[672]), "torch.Tensor(float32, (5, 128, 6, 6))")	# Call self.reflection_pad(x) (line 2)
+        self.assertEqual(str(id2type[673]), "torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, 6, 6))")	# Attribute self.reflection_pad (line 2)
+        self.assertEqual(str(id2type[674]), "class ConvLayer")	# Name self (line 2)
+        self.assertEqual(str(id2type[677]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name x (line 2)
+        self.assertEqual(str(id2type[679]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[680]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name out (line 3)
+        self.assertEqual(str(id2type[682]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Call self.conv2d(out) (line 3)
+        self.assertEqual(str(id2type[683]), "torch.Tensor(float32, (5, 128, 6, 6)) -> torch.Tensor(float32, (5, 128, 4, 4))")	# Attribute self.conv2d (line 3)
+        self.assertEqual(str(id2type[684]), "class ConvLayer")	# Name self (line 3)
+        self.assertEqual(str(id2type[687]), "torch.Tensor(float32, (5, 128, 6, 6))")	# Name out (line 3)
+        self.assertEqual(str(id2type[689]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Return
+        self.assertEqual(str(id2type[690]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name out (line 4)
+        self.assertEqual(str(id2type[692]), "class ConvLayer -> torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, 4, 4))")	# FunctionDef forward (line 1)
+        self.assertEqual(str(id2type[698]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[699]), "torch.Tensor(float32, (5, 128, 6, 6))")	# Name out (line 2)
+        self.assertEqual(str(id2type[701]), "torch.Tensor(float32, (5, 128, 6, 6))")	# Call self.reflection_pad(x) (line 2)
+        self.assertEqual(str(id2type[702]), "torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, 6, 6))")	# Attribute self.reflection_pad (line 2)
+        self.assertEqual(str(id2type[703]), "class ConvLayer")	# Name self (line 2)
+        self.assertEqual(str(id2type[706]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name x (line 2)
+        self.assertEqual(str(id2type[708]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[709]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name out (line 3)
+        self.assertEqual(str(id2type[711]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Call self.conv2d(out) (line 3)
+        self.assertEqual(str(id2type[712]), "torch.Tensor(float32, (5, 128, 6, 6)) -> torch.Tensor(float32, (5, 128, 4, 4))")	# Attribute self.conv2d (line 3)
+        self.assertEqual(str(id2type[713]), "class ConvLayer")	# Name self (line 3)
+        self.assertEqual(str(id2type[716]), "torch.Tensor(float32, (5, 128, 6, 6))")	# Name out (line 3)
+        self.assertEqual(str(id2type[718]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Return
+        self.assertEqual(str(id2type[719]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name out (line 4)
+        self.assertEqual(str(id2type[721]), "class ResidualBlock -> torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, None, None))")	# FunctionDef forward (line 1)
+        self.assertEqual(str(id2type[727]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[728]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name residual (line 2)
+        self.assertEqual(str(id2type[730]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name x (line 2)
+        self.assertEqual(str(id2type[732]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[733]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name out (line 3)
+        self.assertEqual(str(id2type[735]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Call self.relu(self.in1(self.conv1(x))) (line 3)
+        self.assertEqual(str(id2type[736]), "torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, 4, 4))")	# Attribute self.relu (line 3)
+        self.assertEqual(str(id2type[737]), "class ResidualBlock")	# Name self (line 3)
+        self.assertEqual(str(id2type[740]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Call self.in1(self.conv1(x)) (line 3)
+        self.assertEqual(str(id2type[741]), "torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, 4, 4))")	# Attribute self.in1 (line 3)
+        self.assertEqual(str(id2type[742]), "class ResidualBlock")	# Name self (line 3)
+        self.assertEqual(str(id2type[745]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Call self.conv1(x) (line 3)
+        self.assertEqual(str(id2type[746]), "torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, 4, 4))")	# Attribute self.conv1 (line 3)
+        self.assertEqual(str(id2type[747]), "class ResidualBlock")	# Name self (line 3)
+        self.assertEqual(str(id2type[750]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name x (line 3)
+        self.assertEqual(str(id2type[752]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[753]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name out (line 4)
+        self.assertEqual(str(id2type[755]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Call self.in2(self.conv2(out)) (line 4)
+        self.assertEqual(str(id2type[756]), "torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, 4, 4))")	# Attribute self.in2 (line 4)
+        self.assertEqual(str(id2type[757]), "class ResidualBlock")	# Name self (line 4)
+        self.assertEqual(str(id2type[760]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Call self.conv2(out) (line 4)
+        self.assertEqual(str(id2type[761]), "torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, 4, 4))")	# Attribute self.conv2 (line 4)
+        self.assertEqual(str(id2type[762]), "class ResidualBlock")	# Name self (line 4)
+        self.assertEqual(str(id2type[765]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name out (line 4)
+        self.assertEqual(str(id2type[767]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[768]), "torch.Tensor(float32, (5, 128, None, None))")	# Name out (line 5)
+        self.assertEqual(str(id2type[770]), "torch.Tensor(float32, (5, 128, None, None))")	# BinOp out + residual (line 5)
+        self.assertEqual(str(id2type[771]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name out (line 5)
+        self.assertEqual(str(id2type[773]), "torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, None, None))")	# Add
+        self.assertEqual(str(id2type[774]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name residual (line 5)
+        self.assertEqual(str(id2type[776]), "torch.Tensor(float32, (5, 128, None, None))")	# Return
+        self.assertEqual(str(id2type[777]), "torch.Tensor(float32, (5, 128, None, None))")	# Name out (line 6)
+        self.assertEqual(str(id2type[779]), "class ConvLayer -> torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, 4, 4))")	# FunctionDef forward (line 1)
+        self.assertEqual(str(id2type[785]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[786]), "torch.Tensor(float32, (5, 128, 6, 6))")	# Name out (line 2)
+        self.assertEqual(str(id2type[788]), "torch.Tensor(float32, (5, 128, 6, 6))")	# Call self.reflection_pad(x) (line 2)
+        self.assertEqual(str(id2type[789]), "torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, 6, 6))")	# Attribute self.reflection_pad (line 2)
+        self.assertEqual(str(id2type[790]), "class ConvLayer")	# Name self (line 2)
+        self.assertEqual(str(id2type[793]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name x (line 2)
+        self.assertEqual(str(id2type[795]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[796]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name out (line 3)
+        self.assertEqual(str(id2type[798]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Call self.conv2d(out) (line 3)
+        self.assertEqual(str(id2type[799]), "torch.Tensor(float32, (5, 128, 6, 6)) -> torch.Tensor(float32, (5, 128, 4, 4))")	# Attribute self.conv2d (line 3)
+        self.assertEqual(str(id2type[800]), "class ConvLayer")	# Name self (line 3)
+        self.assertEqual(str(id2type[803]), "torch.Tensor(float32, (5, 128, 6, 6))")	# Name out (line 3)
+        self.assertEqual(str(id2type[805]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Return
+        self.assertEqual(str(id2type[806]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name out (line 4)
+        self.assertEqual(str(id2type[808]), "class ConvLayer -> torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, 4, 4))")	# FunctionDef forward (line 1)
+        self.assertEqual(str(id2type[814]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[815]), "torch.Tensor(float32, (5, 128, 6, 6))")	# Name out (line 2)
+        self.assertEqual(str(id2type[817]), "torch.Tensor(float32, (5, 128, 6, 6))")	# Call self.reflection_pad(x) (line 2)
+        self.assertEqual(str(id2type[818]), "torch.Tensor(float32, (5, 128, 4, 4)) -> torch.Tensor(float32, (5, 128, 6, 6))")	# Attribute self.reflection_pad (line 2)
+        self.assertEqual(str(id2type[819]), "class ConvLayer")	# Name self (line 2)
+        self.assertEqual(str(id2type[822]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name x (line 2)
+        self.assertEqual(str(id2type[824]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[825]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name out (line 3)
+        self.assertEqual(str(id2type[827]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Call self.conv2d(out) (line 3)
+        self.assertEqual(str(id2type[828]), "torch.Tensor(float32, (5, 128, 6, 6)) -> torch.Tensor(float32, (5, 128, 4, 4))")	# Attribute self.conv2d (line 3)
+        self.assertEqual(str(id2type[829]), "class ConvLayer")	# Name self (line 3)
+        self.assertEqual(str(id2type[832]), "torch.Tensor(float32, (5, 128, 6, 6))")	# Name out (line 3)
+        self.assertEqual(str(id2type[834]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Return
+        self.assertEqual(str(id2type[835]), "torch.Tensor(float32, (5, 128, 4, 4))")	# Name out (line 4)
+        self.assertEqual(str(id2type[837]), "class UpsampleConvLayer -> torch.Tensor(float32, (5, 128, None, None)) -> torch.Tensor(float32, (5, 64, None, None))")	# FunctionDef forward (line 1)
+        self.assertEqual(str(id2type[843]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[844]), "torch.Tensor(float32, (5, 128, None, None))")	# Name x_in (line 2)
+        self.assertEqual(str(id2type[846]), "torch.Tensor(float32, (5, 128, None, None))")	# Name x (line 2)
+        self.assertEqual(str(id2type[848]), "NoneType")	# If
+        self.assertEqual(str(id2type[849]), "int")	# Attribute self.upsample (line 3)
+        self.assertEqual(str(id2type[850]), "class UpsampleConvLayer")	# Name self (line 3)
+        self.assertEqual(str(id2type[853]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[854]), "torch.Tensor(float32, (5, 128, None, None))")	# Name x_in (line 4)
+        self.assertEqual(str(id2type[856]), "torch.Tensor(float32, (5, 128, None, None))")	# Call torch.nn.functional.interpolate(x_in, mode='nearest', scale_factor=self.upsample) (line 4)
+        self.assertEqual(str(id2type[857]), "torch.Tensor(float32, (5, 128, None, None)) -> torch.Tensor(float32, (5, 128, None, None))")	# Attribute torch.nn.functional.interpolate (line 4)
+        self.assertEqual(str(id2type[858]), "class module")	# Attribute torch.nn.functional (line 4)
+        self.assertEqual(str(id2type[859]), "class module")	# Attribute torch.nn (line 4)
+        self.assertEqual(str(id2type[865]), "torch.Tensor(float32, (5, 128, None, None))")	# Name x_in (line 4)
+        self.assertEqual(str(id2type[868]), "string")	# Constant 'nearest' (line 4)
+        self.assertEqual(str(id2type[870]), "int")	# Attribute self.upsample (line 4)
+        self.assertEqual(str(id2type[871]), "class UpsampleConvLayer")	# Name self (line 4)
+        self.assertEqual(str(id2type[874]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[875]), "torch.Tensor(float32, (5, 128, None, None))")	# Name out (line 5)
+        self.assertEqual(str(id2type[877]), "torch.Tensor(float32, (5, 128, None, None))")	# Call self.reflection_pad(x_in) (line 5)
+        self.assertEqual(str(id2type[878]), "torch.Tensor(float32, (5, 128, None, None)) -> torch.Tensor(float32, (5, 128, None, None))")	# Attribute self.reflection_pad (line 5)
+        self.assertEqual(str(id2type[879]), "class UpsampleConvLayer")	# Name self (line 5)
+        self.assertEqual(str(id2type[882]), "torch.Tensor(float32, (5, 128, None, None))")	# Name x_in (line 5)
+        self.assertEqual(str(id2type[884]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[885]), "torch.Tensor(float32, (5, 64, None, None))")	# Name out (line 6)
+        self.assertEqual(str(id2type[887]), "torch.Tensor(float32, (5, 64, None, None))")	# Call self.conv2d(out) (line 6)
+        self.assertEqual(str(id2type[888]), "torch.Tensor(float32, (5, 128, None, None)) -> torch.Tensor(float32, (5, 64, None, None))")	# Attribute self.conv2d (line 6)
+        self.assertEqual(str(id2type[889]), "class UpsampleConvLayer")	# Name self (line 6)
+        self.assertEqual(str(id2type[892]), "torch.Tensor(float32, (5, 128, None, None))")	# Name out (line 6)
+        self.assertEqual(str(id2type[894]), "torch.Tensor(float32, (5, 64, None, None))")	# Return
+        self.assertEqual(str(id2type[895]), "torch.Tensor(float32, (5, 64, None, None))")	# Name out (line 7)
+        self.assertEqual(str(id2type[897]), "class UpsampleConvLayer -> torch.Tensor(float32, (5, 64, None, None)) -> torch.Tensor(float32, (5, 32, None, None))")	# FunctionDef forward (line 1)
+        self.assertEqual(str(id2type[903]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[904]), "torch.Tensor(float32, (5, 64, None, None))")	# Name x_in (line 2)
+        self.assertEqual(str(id2type[906]), "torch.Tensor(float32, (5, 64, None, None))")	# Name x (line 2)
+        self.assertEqual(str(id2type[908]), "NoneType")	# If
+        self.assertEqual(str(id2type[909]), "int")	# Attribute self.upsample (line 3)
+        self.assertEqual(str(id2type[910]), "class UpsampleConvLayer")	# Name self (line 3)
+        self.assertEqual(str(id2type[913]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[914]), "torch.Tensor(float32, (5, 64, None, None))")	# Name x_in (line 4)
+        self.assertEqual(str(id2type[916]), "torch.Tensor(float32, (5, 64, None, None))")	# Call torch.nn.functional.interpolate(x_in, mode='nearest', scale_factor=self.upsample) (line 4)
+        self.assertEqual(str(id2type[917]), "torch.Tensor(float32, (5, 64, None, None)) -> torch.Tensor(float32, (5, 64, None, None))")	# Attribute torch.nn.functional.interpolate (line 4)
+        self.assertEqual(str(id2type[918]), "class module")	# Attribute torch.nn.functional (line 4)
+        self.assertEqual(str(id2type[919]), "class module")	# Attribute torch.nn (line 4)
+        self.assertEqual(str(id2type[925]), "torch.Tensor(float32, (5, 64, None, None))")	# Name x_in (line 4)
+        self.assertEqual(str(id2type[928]), "string")	# Constant 'nearest' (line 4)
+        self.assertEqual(str(id2type[930]), "int")	# Attribute self.upsample (line 4)
+        self.assertEqual(str(id2type[931]), "class UpsampleConvLayer")	# Name self (line 4)
+        self.assertEqual(str(id2type[934]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[935]), "torch.Tensor(float32, (5, 64, None, None))")	# Name out (line 5)
+        self.assertEqual(str(id2type[937]), "torch.Tensor(float32, (5, 64, None, None))")	# Call self.reflection_pad(x_in) (line 5)
+        self.assertEqual(str(id2type[938]), "torch.Tensor(float32, (5, 64, None, None)) -> torch.Tensor(float32, (5, 64, None, None))")	# Attribute self.reflection_pad (line 5)
+        self.assertEqual(str(id2type[939]), "class UpsampleConvLayer")	# Name self (line 5)
+        self.assertEqual(str(id2type[942]), "torch.Tensor(float32, (5, 64, None, None))")	# Name x_in (line 5)
+        self.assertEqual(str(id2type[944]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[945]), "torch.Tensor(float32, (5, 32, None, None))")	# Name out (line 6)
+        self.assertEqual(str(id2type[947]), "torch.Tensor(float32, (5, 32, None, None))")	# Call self.conv2d(out) (line 6)
+        self.assertEqual(str(id2type[948]), "torch.Tensor(float32, (5, 64, None, None)) -> torch.Tensor(float32, (5, 32, None, None))")	# Attribute self.conv2d (line 6)
+        self.assertEqual(str(id2type[949]), "class UpsampleConvLayer")	# Name self (line 6)
+        self.assertEqual(str(id2type[952]), "torch.Tensor(float32, (5, 64, None, None))")	# Name out (line 6)
+        self.assertEqual(str(id2type[954]), "torch.Tensor(float32, (5, 32, None, None))")	# Return
+        self.assertEqual(str(id2type[955]), "torch.Tensor(float32, (5, 32, None, None))")	# Name out (line 7)
+        self.assertEqual(str(id2type[957]), "class ConvLayer -> torch.Tensor(float32, (5, 32, None, None)) -> torch.Tensor(float32, (5, 3, None, None))")	# FunctionDef forward (line 1)
+        self.assertEqual(str(id2type[963]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[964]), "torch.Tensor(float32, (5, 32, None, None))")	# Name out (line 2)
+        self.assertEqual(str(id2type[966]), "torch.Tensor(float32, (5, 32, None, None))")	# Call self.reflection_pad(x) (line 2)
+        self.assertEqual(str(id2type[967]), "torch.Tensor(float32, (5, 32, None, None)) -> torch.Tensor(float32, (5, 32, None, None))")	# Attribute self.reflection_pad (line 2)
+        self.assertEqual(str(id2type[968]), "class ConvLayer")	# Name self (line 2)
+        self.assertEqual(str(id2type[971]), "torch.Tensor(float32, (5, 32, None, None))")	# Name x (line 2)
+        self.assertEqual(str(id2type[973]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[974]), "torch.Tensor(float32, (5, 3, None, None))")	# Name out (line 3)
+        self.assertEqual(str(id2type[976]), "torch.Tensor(float32, (5, 3, None, None))")	# Call self.conv2d(out) (line 3)
+        self.assertEqual(str(id2type[977]), "torch.Tensor(float32, (5, 32, None, None)) -> torch.Tensor(float32, (5, 3, None, None))")	# Attribute self.conv2d (line 3)
+        self.assertEqual(str(id2type[978]), "class ConvLayer")	# Name self (line 3)
+        self.assertEqual(str(id2type[981]), "torch.Tensor(float32, (5, 32, None, None))")	# Name out (line 3)
+        self.assertEqual(str(id2type[983]), "torch.Tensor(float32, (5, 3, None, None))")	# Return
+        self.assertEqual(str(id2type[984]), "torch.Tensor(float32, (5, 3, None, None))")	# Name out (line 4)
+
+
+def main():
+    unittest.main()
+
+if __name__ == '__main__':
+    main()

--- a/tests/elichika_typing/pytorch/examples/vae.py
+++ b/tests/elichika_typing/pytorch/examples/vae.py
@@ -1,0 +1,115 @@
+import torch
+import torch.nn as nn
+import unittest
+
+from chainer_compiler.elichika.testtools import generate_id2type_from_forward
+from chainer_compiler.elichika.testtools import type_inference_tools
+
+from testcases.pytorch.examples.vae      import gen_VAE_test
+
+
+class TestVAE(unittest.TestCase):
+    def test_VAE(self):
+        type_inference_tools.reset_state()
+
+        model, forward_args = gen_VAE_test()
+        id2type = generate_id2type_from_forward(model, forward_args)
+
+        self.assertEqual(str(id2type[1]), "class VAE -> torch.Tensor(float32, (128, 1, 28, 28)) -> (torch.Tensor(float32, (128, 784)), torch.Tensor(float32, (128, 20)), torch.Tensor(float32, (128, 20)))")	# FunctionDef forward (line 1)
+        self.assertEqual(str(id2type[7]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[8]), "(torch.Tensor(float32, (128, 20)), torch.Tensor(float32, (128, 20)))")	# Tuple (mu, logvar) (line 2)
+        self.assertEqual(str(id2type[9]), "torch.Tensor(float32, (128, 20))")	# Name mu (line 2)
+        self.assertEqual(str(id2type[11]), "torch.Tensor(float32, (128, 20))")	# Name logvar (line 2)
+        self.assertEqual(str(id2type[14]), "(torch.Tensor(float32, (128, 20)), torch.Tensor(float32, (128, 20)))")	# Call self.encode(x.view(-1, 784)) (line 2)
+        self.assertEqual(str(id2type[15]), "torch.Tensor(float32, (128, 784)) -> (torch.Tensor(float32, (128, 20)), torch.Tensor(float32, (128, 20)))")	# Attribute self.encode (line 2)
+        self.assertEqual(str(id2type[16]), "class VAE")	# Name self (line 2)
+        self.assertEqual(str(id2type[19]), "torch.Tensor(float32, (128, 784))")	# Call x.view(-1, 784) (line 2)
+        self.assertEqual(str(id2type[20]), "int -> int -> torch.Tensor(float32, (128, 784))")	# Attribute x.view (line 2)
+        self.assertEqual(str(id2type[21]), "torch.Tensor(float32, (128, 1, 28, 28))")	# Name x (line 2)
+        self.assertEqual(str(id2type[24]), "int")	# UnaryOp -1 (line 2)
+        self.assertEqual(str(id2type[26]), "int")	# Constant 1 (line 2)
+        self.assertEqual(str(id2type[27]), "int")	# Constant 784 (line 2)
+        self.assertEqual(str(id2type[28]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[29]), "torch.Tensor(float32, (128, 20))")	# Name z (line 3)
+        self.assertEqual(str(id2type[31]), "torch.Tensor(float32, (128, 20))")	# Call self.reparameterize(mu, logvar) (line 3)
+        self.assertEqual(str(id2type[32]), "torch.Tensor(float32, (128, 20)) -> torch.Tensor(float32, (128, 20)) -> torch.Tensor(float32, (128, 20))")	# Attribute self.reparameterize (line 3)
+        self.assertEqual(str(id2type[33]), "class VAE")	# Name self (line 3)
+        self.assertEqual(str(id2type[36]), "torch.Tensor(float32, (128, 20))")	# Name mu (line 3)
+        self.assertEqual(str(id2type[38]), "torch.Tensor(float32, (128, 20))")	# Name logvar (line 3)
+        self.assertEqual(str(id2type[40]), "(torch.Tensor(float32, (128, 784)), torch.Tensor(float32, (128, 20)), torch.Tensor(float32, (128, 20)))")	# Return
+        self.assertEqual(str(id2type[41]), "(torch.Tensor(float32, (128, 784)), torch.Tensor(float32, (128, 20)), torch.Tensor(float32, (128, 20)))")	# Tuple (self.decode(z), mu, logvar) (line 4)
+        self.assertEqual(str(id2type[42]), "torch.Tensor(float32, (128, 784))")	# Call self.decode(z) (line 4)
+        self.assertEqual(str(id2type[43]), "torch.Tensor(float32, (128, 20)) -> torch.Tensor(float32, (128, 784))")	# Attribute self.decode (line 4)
+        self.assertEqual(str(id2type[44]), "class VAE")	# Name self (line 4)
+        self.assertEqual(str(id2type[47]), "torch.Tensor(float32, (128, 20))")	# Name z (line 4)
+        self.assertEqual(str(id2type[49]), "torch.Tensor(float32, (128, 20))")	# Name mu (line 4)
+        self.assertEqual(str(id2type[51]), "torch.Tensor(float32, (128, 20))")	# Name logvar (line 4)
+        self.assertEqual(str(id2type[54]), "class VAE -> torch.Tensor(float32, (128, 784)) -> (torch.Tensor(float32, (128, 20)), torch.Tensor(float32, (128, 20)))")	# FunctionDef encode (line 1)
+        self.assertEqual(str(id2type[60]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[61]), "torch.Tensor(float32, (128, 400))")	# Name h1 (line 2)
+        self.assertEqual(str(id2type[63]), "torch.Tensor(float32, (128, 400))")	# Call F.relu(self.fc1(x)) (line 2)
+        self.assertEqual(str(id2type[64]), "torch.Tensor(float32, (128, 400)) -> torch.Tensor(float32, (128, 400))")	# Attribute F.relu (line 2)
+        self.assertEqual(str(id2type[68]), "torch.Tensor(float32, (128, 400))")	# Call self.fc1(x) (line 2)
+        self.assertEqual(str(id2type[69]), "torch.Tensor(float32, (128, 784)) -> torch.Tensor(float32, (128, 400))")	# Attribute self.fc1 (line 2)
+        self.assertEqual(str(id2type[70]), "class VAE")	# Name self (line 2)
+        self.assertEqual(str(id2type[73]), "torch.Tensor(float32, (128, 784))")	# Name x (line 2)
+        self.assertEqual(str(id2type[75]), "(torch.Tensor(float32, (128, 20)), torch.Tensor(float32, (128, 20)))")	# Return
+        self.assertEqual(str(id2type[76]), "(torch.Tensor(float32, (128, 20)), torch.Tensor(float32, (128, 20)))")	# Tuple (self.fc21(h1), self.fc22(h1)) (line 3)
+        self.assertEqual(str(id2type[77]), "torch.Tensor(float32, (128, 20))")	# Call self.fc21(h1) (line 3)
+        self.assertEqual(str(id2type[78]), "torch.Tensor(float32, (128, 400)) -> torch.Tensor(float32, (128, 20))")	# Attribute self.fc21 (line 3)
+        self.assertEqual(str(id2type[79]), "class VAE")	# Name self (line 3)
+        self.assertEqual(str(id2type[82]), "torch.Tensor(float32, (128, 400))")	# Name h1 (line 3)
+        self.assertEqual(str(id2type[84]), "torch.Tensor(float32, (128, 20))")	# Call self.fc22(h1) (line 3)
+        self.assertEqual(str(id2type[85]), "torch.Tensor(float32, (128, 400)) -> torch.Tensor(float32, (128, 20))")	# Attribute self.fc22 (line 3)
+        self.assertEqual(str(id2type[86]), "class VAE")	# Name self (line 3)
+        self.assertEqual(str(id2type[89]), "torch.Tensor(float32, (128, 400))")	# Name h1 (line 3)
+        self.assertEqual(str(id2type[92]), "class VAE -> torch.Tensor(float32, (128, 20)) -> torch.Tensor(float32, (128, 20)) -> torch.Tensor(float32, (128, 20))")	# FunctionDef reparameterize (line 1)
+        self.assertEqual(str(id2type[100]), "torch.Tensor(float32, (128, 20))")	# If
+        self.assertEqual(str(id2type[101]), "bool")	# Attribute self.training (line 2)
+        self.assertEqual(str(id2type[102]), "class VAE")	# Name self (line 2)
+        self.assertEqual(str(id2type[105]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[106]), "torch.Tensor(float32, (128, 20))")	# Name std (line 3)
+        self.assertEqual(str(id2type[108]), "torch.Tensor(float32, (128, 20))")	# Call torch.exp(0.5 * logvar) (line 3)
+        self.assertEqual(str(id2type[109]), "torch.Tensor(float32, (128, 20)) -> torch.Tensor(float32, (128, 20))")	# Attribute torch.exp (line 3)
+        self.assertEqual(str(id2type[113]), "torch.Tensor(float32, (128, 20))")	# BinOp 0.5 * logvar (line 3)
+        self.assertEqual(str(id2type[114]), "float")	# Constant 0.5 (line 3)
+        self.assertEqual(str(id2type[115]), "float -> torch.Tensor(float32, (128, 20)) -> torch.Tensor(float32, (128, 20))")	# Mult
+        self.assertEqual(str(id2type[116]), "torch.Tensor(float32, (128, 20))")	# Name logvar (line 3)
+        self.assertEqual(str(id2type[118]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[119]), "torch.Tensor(float32, (128, 20))")	# Name eps (line 4)
+        self.assertEqual(str(id2type[121]), "torch.Tensor(float32, (128, 20))")	# Call torch.randn_like(std) (line 4)
+        self.assertEqual(str(id2type[122]), "torch.Tensor(float32, (128, 20)) -> torch.Tensor(float32, (128, 20))")	# Attribute torch.randn_like (line 4)
+        self.assertEqual(str(id2type[126]), "torch.Tensor(float32, (128, 20))")	# Name std (line 4)
+        self.assertEqual(str(id2type[128]), "torch.Tensor(float32, (128, 20))")	# Return
+        self.assertEqual(str(id2type[129]), "torch.Tensor(float32, (128, 20))")	# Call eps.mul(std).add_(mu) (line 5)
+        self.assertEqual(str(id2type[130]), "torch.Tensor(float32, (128, 20)) -> torch.Tensor(float32, (128, 20))")	# Attribute eps.mul(std).add_ (line 5)
+        self.assertEqual(str(id2type[131]), "torch.Tensor(float32, (128, 20))")	# Call eps.mul(std) (line 5)
+        self.assertEqual(str(id2type[132]), "torch.Tensor(float32, (128, 20)) -> torch.Tensor(float32, (128, 20))")	# Attribute eps.mul (line 5)
+        self.assertEqual(str(id2type[133]), "torch.Tensor(float32, (128, 20))")	# Name eps (line 5)
+        self.assertEqual(str(id2type[136]), "torch.Tensor(float32, (128, 20))")	# Name std (line 5)
+        self.assertEqual(str(id2type[139]), "torch.Tensor(float32, (128, 20))")	# Name mu (line 5)
+        self.assertEqual(str(id2type[141]), "torch.Tensor(float32, (128, 20))")	# Return
+        self.assertEqual(str(id2type[142]), "torch.Tensor(float32, (128, 20))")	# Name mu (line 7)
+        self.assertEqual(str(id2type[144]), "class VAE -> torch.Tensor(float32, (128, 20)) -> torch.Tensor(float32, (128, 784))")	# FunctionDef decode (line 1)
+        self.assertEqual(str(id2type[150]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[151]), "torch.Tensor(float32, (128, 400))")	# Name h3 (line 2)
+        self.assertEqual(str(id2type[153]), "torch.Tensor(float32, (128, 400))")	# Call F.relu(self.fc3(z)) (line 2)
+        self.assertEqual(str(id2type[154]), "torch.Tensor(float32, (128, 400)) -> torch.Tensor(float32, (128, 400))")	# Attribute F.relu (line 2)
+        self.assertEqual(str(id2type[158]), "torch.Tensor(float32, (128, 400))")	# Call self.fc3(z) (line 2)
+        self.assertEqual(str(id2type[159]), "torch.Tensor(float32, (128, 20)) -> torch.Tensor(float32, (128, 400))")	# Attribute self.fc3 (line 2)
+        self.assertEqual(str(id2type[160]), "class VAE")	# Name self (line 2)
+        self.assertEqual(str(id2type[163]), "torch.Tensor(float32, (128, 20))")	# Name z (line 2)
+        self.assertEqual(str(id2type[165]), "torch.Tensor(float32, (128, 784))")	# Return
+        self.assertEqual(str(id2type[166]), "torch.Tensor(float32, (128, 784))")	# Call torch.sigmoid(self.fc4(h3)) (line 3)
+        self.assertEqual(str(id2type[167]), "torch.Tensor(float32, (128, 784)) -> torch.Tensor(float32, (128, 784))")	# Attribute torch.sigmoid (line 3)
+        self.assertEqual(str(id2type[171]), "torch.Tensor(float32, (128, 784))")	# Call self.fc4(h3) (line 3)
+        self.assertEqual(str(id2type[172]), "torch.Tensor(float32, (128, 400)) -> torch.Tensor(float32, (128, 784))")	# Attribute self.fc4 (line 3)
+        self.assertEqual(str(id2type[173]), "class VAE")	# Name self (line 3)
+        self.assertEqual(str(id2type[176]), "torch.Tensor(float32, (128, 400))")	# Name h3 (line 3)
+
+
+def main():
+    unittest.main()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This PR adds test cases and expectations for the type inference engine.
The test cases cover most of the models defined in [pytorch/examples](https://github.com/pytorch/examples) except for the ones under word_language_model and reinforcement_learning.