### PR TITLE
Fix join() to avoid returning optional(optional(t))

### DIFF
--- a/chainer_compiler/elichika/typing/types.py
+++ b/chainer_compiler/elichika/typing/types.py
@@ -727,8 +727,12 @@ def join(ty1, ty2):
         return TyNone()
 
     if isinstance(ty1, TyNone):
+        if isinstance(ty2, TyOptional):
+            return ty2
         return TyOptional(ty2)
     if isinstance(ty2, TyNone):
+        if isinstance(ty1, TyOptional):
+            return ty1
         return TyOptional(ty1)
 
     if isinstance(ty1, TyOptional) and isinstance(ty2, TyOptional):


### PR DESCRIPTION
This PR fixes the definition of `join` to avoid the nested optional type to appear in the result.