### PR TITLE
Fixate type of list in a program

### DIFF
--- a/chainer_compiler/elichika/typing/shape_elem.py
+++ b/chainer_compiler/elichika/typing/shape_elem.py
@@ -253,6 +253,7 @@ def unify_shape(shape1, shape2):
     for e1, e2 in zip(shape1, shape2):
         if e1.value != e2.value:
             e1.value = e2.value = None
+    return shape1
 
 
 def join_shape(shape1, shape2):

--- a/chainer_compiler/elichika/typing/std/builtin_ops.py
+++ b/chainer_compiler/elichika/typing/std/builtin_ops.py
@@ -1,0 +1,50 @@
+import gast
+
+from   chainer_compiler.elichika.typing.types      import *
+from   chainer_compiler.elichika.typing.ext.common import ty_TensorArith
+
+__all__ = [ 'ty_ops' ]
+
+
+def ty_ops(op, tyl, tyr):
+    if isinstance(tyl, TySequence) and isinstance(tyr, TyNum):
+        assert tyr.is_int()
+        assert isinstance(op, gast.Mult)
+        if tyr.value is None:
+            return TySequence(tyl.kind, tyl.get())
+        return TySequence(tyl.kind, [tyl.get() for _ in range(tyr.value)])
+
+    if isinstance(tyl, TySequence) and isinstance(tyr, TySequence):
+        assert tyl.kind == tyr.kind
+        assert isinstance(op, gast.Add)
+        if tyl.is_fixed_len and tyr.is_fixed_len and tyl.is_tuple():
+            return TySequence(tyl.kind, tyl.get_tys() + tyr.get_tys())
+        # Always make the length unknown for lists.
+        return TySequence(tyl.kind, join(tyl.get(), tyr.get()))
+
+    if isinstance(tyl, TyString) and (tyr, TyString):
+        if tyl.value is not None and tyr.value is not None:
+            return TyString(tyl.value + tyr.value)
+        return TyString()
+
+    semantics = {
+            gast.Add : (lambda x, y: x + y),
+            gast.Sub : (lambda x, y: x - y),
+            gast.Mult : (lambda x, y: x * y),
+            gast.Div : (lambda x, y: x / y),
+            gast.FloorDiv : (lambda x, y: x // y),
+            }
+    func = semantics[type(op)]
+
+    if isinstance(tyl, TyTensor):
+        return ty_TensorArith(tyl.kind, func)([tyl, tyr], {})
+    if isinstance(tyr, TyTensor):
+        return ty_TensorArith(tyr.kind, func)([tyl, tyr], {})
+
+    assert isinstance(tyl, TyNum) and isinstance(tyr, TyNum)
+
+    vall, valr = generate_dummy_value(tyl), generate_dummy_value(tyr)
+    ty_ret = type_of_value(func(vall, valr))
+    if tyl.value is None or tyr.value is None:
+        ty_ret.value = None
+    return ty_ret

--- a/chainer_compiler/elichika/typing/std/list_functions.py
+++ b/chainer_compiler/elichika/typing/std/list_functions.py
@@ -4,7 +4,7 @@ __all__ = [ 'list_func_ty' ]
 
 def ty_append(ty_args, ty_kwargs):
     ty_list, ty_elem = ty_args
-    unify(ty_list.get(), ty_elem)
+    ty_list._ty = join(ty_list.get(), ty_elem)
     return TyNone()
 
 

--- a/chainer_compiler/elichika/typing/std/list_functions.py
+++ b/chainer_compiler/elichika/typing/std/list_functions.py
@@ -4,7 +4,7 @@ __all__ = [ 'list_func_ty' ]
 
 def ty_append(ty_args, ty_kwargs):
     ty_list, ty_elem = ty_args
-    ty_list._ty = join(ty_list.get(), ty_elem)
+    unify(ty_list, TyList(ty_elem))
     return TyNone()
 
 

--- a/chainer_compiler/elichika/typing/type_inference.py
+++ b/chainer_compiler/elichika/typing/type_inference.py
@@ -486,19 +486,8 @@ class InferenceEngine():
         ty_val = self.infer_expr(node.value)
 
         if isinstance(target, gast.Name):
-            if ty_val.is_mutable() and \
-                    isinstance(node.value, (gast.Name, gast.Attribute)):
-                # XXX: alias
-                self.tyenv[target.id] = ty_val
-                self.nodetype[target] = ty_val
-                return
-
-            # XXX: Changing following 2 lines into
-            #   self.tyenv[target.id] = self.nodetype[target] = copy_ty(ty_val)
-            # will allow self.nodetype[target] to change afterwards, which will
-            # be more suitable for elichika but contradict with python semantics.
-            self.tyenv[target.id] = copy_ty(ty_val)
-            self.nodetype[target] = copy_ty(ty_val)
+            self.tyenv[target.id] = ty_val
+            self.nodetype[target] = ty_val
             return
 
         if isinstance(target, gast.Attribute):
@@ -534,20 +523,12 @@ class InferenceEngine():
             unify(ty_target, ty_val)
 
         if isinstance(node.target, gast.Name):
-            if ty_target.is_mutable():
-                self.tyenv[node.target.id] = ty_val
-            else:
-                self.tyenv[node.target.id] = copy_ty(ty_val)
+            self.tyenv[node.target.id] = ty_val
 
         if isinstance(node.target, gast.Attribute):
             ty_obj = self.nodetype[node.target.value]
             assert isinstance(ty_obj, TyUserDefinedClass)
-            if ty_target.is_mutable():
-                self.attribute_tyenv[(ty_obj.instance, node.target.attr)] = \
-                        ty_val
-            else:
-                self.attribute_tyenv[(ty_obj.instance, node.target.attr)] = \
-                        copy_ty(ty_val)
+            self.attribute_tyenv[(ty_obj.instance, node.target.attr)] = ty_val
 
         self.nodetype[node.target] = ty_val
 

--- a/chainer_compiler/elichika/typing/type_inference.py
+++ b/chainer_compiler/elichika/typing/type_inference.py
@@ -715,8 +715,6 @@ class InferenceEngine():
         if isinstance(ty_iteration, TyTensor):
             ty_i_ = TyTensor(ty_iteration.kind, ty_iteration.dtype,
                     ty_iteration.shape[1:])
-            if ty_iteration.shape is not None:
-                ty_i_.shape = ty_iteration.shape[1:]
             unify(ty_i, ty_i_)
         else:
             unify(TySequence(None, ty_i), ty_iteration)

--- a/chainer_compiler/elichika/typing/types.py
+++ b/chainer_compiler/elichika/typing/types.py
@@ -31,8 +31,6 @@ class TyObj():  # base type, meaning 'unknown'
     def __repr__(self):
         return self.__str__()
 
-    def is_mutable(self):
-        pass
     # dereference internal type
     def deref(self):
         return self
@@ -44,8 +42,6 @@ class TyNone(TyObj):
         return "NoneType"
     def __eq__(self, other):
         return isinstance(other, TyNone)
-    def is_mutable(self):
-        return False
 
 
 class NumKind(IntEnum):
@@ -74,9 +70,6 @@ class TyNum(TyObj):
     def __eq__(self, other):
         return isinstance(other, TyNum) and self.kind == other.kind
 
-    def is_mutable(self):
-        return False
-
     def coerce_value(self):
         if self.value is None:
             return
@@ -104,8 +97,6 @@ class TyString(TyObj):
         return "string"
     def __eq__(self, other):
         return isinstance(other, TyString)
-    def is_mutable(self):
-        return False
 
 
 class TyArrow(TyObj):
@@ -122,9 +113,6 @@ class TyArrow(TyObj):
     def __eq__(self, other):
         return isinstance(other, TyArrow) and self.argty == other.argty and \
                 self.retty == other.retty
-
-    def is_mutable(self):
-        return False
 
     def deref(self):
         self.argty = [t.deref() for t in self.argty]
@@ -168,9 +156,6 @@ class TySequence(TyObj):
     def __getitem__(self, i):
         assert self.is_fixed_len
         return self._ty[i]
-
-    def is_mutable(self):
-        return self.kind == SequenceKind.LIST
 
     def size(self):
         if self.is_fixed_len:
@@ -238,9 +223,6 @@ class TyDict(TyObj):
         return isinstance(other, TyDict) and self.keyty == other.keyty and \
                 self.valty == other.valty
 
-    def is_mutable(self):
-        return True
-
     def deref(self):
         self.keyty = self.keyty.deref()
         self.valty = self.valty.deref()
@@ -256,9 +238,6 @@ class TyUserDefinedClass(TyObj):
 
     def show(self):
         return "class " + self.name
-
-    def is_mutable(self):
-        return True
 
 
 class TyOptional(TyObj):
@@ -309,9 +288,6 @@ class TyTensor(TyObj):
     def __eq__(self, other):
         # TODO: shape?
         return isinstance(other, TyTensor) and self.dtype == other.dtype
-
-    def is_mutable(self):
-        return True
 
     def is_ndarray(self):
         return self.kind == TensorKind.ndarray
@@ -386,11 +362,6 @@ class TyVar(TyObj):
         if self.ty is None:
             return self is other
         return self.deref() == other.deref()
-
-    def is_mutable(self):
-        if self.is_set:
-            return self.ty.is_mutable()
-        return False
 
     def set(self, ty):
         assert self.is_set == False

--- a/chainer_compiler/elichika/typing/types.py
+++ b/chainer_compiler/elichika/typing/types.py
@@ -624,10 +624,14 @@ def unify(ty1, ty2):
         ty1.kind = ty2.kind = max(ty1.kind, ty2.kind)
         ty1.coerce_value()
         ty2.coerce_value()
-        return copy_ty(ty1)
+        if ty1.value == ty2.value:
+            return TyNum(ty1.kind, ty1.value)
+        return TyNum(ty1.kind)
 
     if isinstance(ty1, TyString) and isinstance(ty2, TyString):
-        return
+        if ty1.value == ty2.value:
+            return TyString(ty1.value)
+        return TyString()
 
     if isinstance(ty1, TySequence) and isinstance(ty2, TySequence):
         if ty1.kind:

--- a/chainer_compiler/elichika/typing/types.py
+++ b/chainer_compiler/elichika/typing/types.py
@@ -619,12 +619,30 @@ def occur(var, ty):
     return False
 
 
+# Solves constraint over type variables and the element of TyList,
+# which needs a special care since it is an invariant type
 def unify(ty1, ty2):
     ty1 = ty1.deref()
     ty2 = ty2.deref()
 
     if isinstance(ty1, TyNone) and isinstance(ty2, TyNone):
         return TyNone()
+
+    if isinstance(ty1, TyNone):
+        if isinstance(ty2, TyOptional):
+            return ty2
+        return TyOptional(ty2)
+    if isinstance(ty2, TyNone):
+        if isinstance(ty1, TyOptional):
+            return ty1
+        return TyOptional(ty1)
+
+    if isinstance(ty1, TyOptional) and isinstance(ty2, TyOptional):
+        return TyOptional(unify(ty1.ty, ty2.ty))
+    if isinstance(ty1, TyOptional):
+        return TyOptional(unify(ty1.ty, ty2))
+    if isinstance(ty2, TyOptional):
+        return TyOptional(unify(ty1, ty2.ty))
 
     if isinstance(ty1, TyVar):
         if isinstance(ty2, TyVar) and ty1 is ty2:

--- a/chainer_compiler/elichika/typing/types.py
+++ b/chainer_compiler/elichika/typing/types.py
@@ -565,8 +565,7 @@ def copy_ty(ty):
             return TySequence(ty.kind, [copy_ty(t) for t in ty.get_tys()])
         return TySequence(ty.kind, copy_ty(ty.get_ty()))
     elif isinstance(ty, TyDict):
-        # XXX: do not copy instance
-        return TyDict(ty.keyty, ty.valty)
+        return TyDict(copy_ty(ty.keyty), copy_ty(ty.valty))
     elif isinstance(ty, TyUserDefinedClass):
         return TyUserDefinedClass(ty.name, ty.instance)
     elif isinstance(ty, TyDType):
@@ -574,10 +573,9 @@ def copy_ty(ty):
     elif isinstance(ty, TyTensor):
         return TyTensor(ty.kind, ty.dtype, ty.shape)
     elif isinstance(ty, TyVar):
-        ret = TyVar(None)
         if ty.ty is not None:
-            ret.set(ty.deref())
-        return ret
+            return ty.deref()
+        return ty
     elif isinstance(ty, TyOptional):
         return TyOptional(ty.ty)
     assert False, "copy_ty: {}".format(ty)
@@ -775,8 +773,7 @@ def join(ty1, ty2):
             return TySequence(kind, join(ty1.get(), ty2.get()))
 
     if isinstance(ty1, TyDict) and isinstance(ty2, TyDict):
-        if ty1.keyty == ty2.keyty and ty1.valty == ty2.valty:
-            return TyDict(ty1.keyty, ty1.valty)
+        return TyDict(join(ty1.keyty, ty2.keyty), join(ty1.valty, ty2.valty))
 
     if isinstance(ty1, TyTensor) and isinstance(ty2, TyTensor):
         if ty1.kind == ty2.kind and ty1.dtype == ty2.dtype and \

--- a/tests/elichika_typing/EspNet_test.py
+++ b/tests/elichika_typing/EspNet_test.py
@@ -224,7 +224,7 @@ class TestEspNet(unittest.TestCase):
         self.assertEqual(str(id2type[114]), "class AttDot")	# Name self (line 25)
         self.assertEqual(str(id2type[119]), "dtype(float32)")	# Attribute np.float32 (line 25)
         self.assertEqual(str(id2type[123]), "NoneType")	# Assign
-        self.assertEqual(str(id2type[124]), "a17")	# Name dec_z (line 27)
+        self.assertEqual(str(id2type[124]), "a15 (from line 27)")	# Name dec_z (line 27)
         self.assertEqual(str(id2type[126]), "a15 (from line 27)")	# Call F.reshape(dec_z, (batch, self.dunits)) (line 27)
         self.assertEqual(str(id2type[127]), "a11 -> (int, int) -> a15 (from line 27)")	# Attribute F.reshape (line 27)
         self.assertEqual(str(id2type[131]), "a11")	# Name dec_z (line 27)
@@ -395,7 +395,7 @@ class TestEspNet(unittest.TestCase):
         self.assertEqual(str(id2type[117]), "class AttLoc")	# Name self (line 27)
         self.assertEqual(str(id2type[122]), "dtype(float32)")	# Attribute np.float32 (line 27)
         self.assertEqual(str(id2type[126]), "NoneType")	# Assign
-        self.assertEqual(str(id2type[127]), "a15")	# Name dec_z_new (line 29)
+        self.assertEqual(str(id2type[127]), "a13 (from line 29)")	# Name dec_z_new (line 29)
         self.assertEqual(str(id2type[129]), "a13 (from line 29)")	# Call F.reshape(dec_z, (batch, self.dunits)) (line 29)
         self.assertEqual(str(id2type[130]), "a9 -> (int, int) -> a13 (from line 29)")	# Attribute F.reshape (line 29)
         self.assertEqual(str(id2type[134]), "a9")	# Name dec_z (line 29)

--- a/tests/elichika_typing/Primitive_test.py
+++ b/tests/elichika_typing/Primitive_test.py
@@ -312,6 +312,34 @@ class TestSequence(unittest.TestCase):
         self.assertEqual(str(id2type[36]), "int")	# Name x (line 2)
 
 
+    def test_list_optional(self):
+        class Test():
+            def forward(self):
+                xs = [1, 2]
+                ys = xs
+                xs.append(None)
+                return ys
+
+        id2type = generate_id2type_from_forward(Test(), ())
+
+        self.assertEqual(str(id2type[1]), "class Test -> optional(int) list")	# FunctionDef forward (line 1)
+        self.assertEqual(str(id2type[5]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[6]), "optional(int) list")	# Name xs (line 2)
+        self.assertEqual(str(id2type[8]), "optional(int) list")	# List [1, 2] (line 2)
+        self.assertEqual(str(id2type[9]), "int")	# Constant 1 (line 2)
+        self.assertEqual(str(id2type[10]), "int")	# Constant 2 (line 2)
+        self.assertEqual(str(id2type[12]), "NoneType")	# Assign
+        self.assertEqual(str(id2type[13]), "optional(int) list")	# Name ys (line 3)
+        self.assertEqual(str(id2type[15]), "optional(int) list")	# Name xs (line 3)
+        self.assertEqual(str(id2type[17]), "NoneType")	# Expr
+        self.assertEqual(str(id2type[18]), "NoneType")	# Call xs.append(None) (line 4)
+        self.assertEqual(str(id2type[19]), "NoneType -> NoneType")	# Attribute xs.append (line 4)
+        self.assertEqual(str(id2type[20]), "optional(int) list")	# Name xs (line 4)
+        self.assertEqual(str(id2type[23]), "NoneType")	# Constant None (line 4)
+        self.assertEqual(str(id2type[24]), "optional(int) list")	# Return
+        self.assertEqual(str(id2type[25]), "optional(int) list")	# Name ys (line 5)
+
+
 # ==============================================================================
 
 class TestOtherDataTypes(unittest.TestCase):
@@ -523,8 +551,8 @@ class TestAssign(unittest.TestCase):
 
         self.assertEqual(str(id2type[1]), "class Test -> int list")	# FunctionDef forward (line 1)
         self.assertEqual(str(id2type[5]), "NoneType")	# Assign (line 2)
-        self.assertEqual(str(id2type[6]), "[int, int, int]")	# Name x (line 2)
-        self.assertEqual(str(id2type[8]), "[int, int, int]")	# List (line 2)
+        self.assertEqual(str(id2type[6]), "int list")	# Name x (line 2)
+        self.assertEqual(str(id2type[8]), "int list")	# List (line 2)
         self.assertEqual(str(id2type[9]), "int")	# Num (line 2)
         self.assertEqual(str(id2type[10]), "int")	# Num (line 2)
         self.assertEqual(str(id2type[11]), "int")	# Num (line 2)

--- a/tests/elichika_typing/pytorch/resnet_test.py
+++ b/tests/elichika_typing/pytorch/resnet_test.py
@@ -131,9 +131,9 @@ class TestResNet(unittest.TestCase):
         self.assertEqual(str(id2type[200]), "class BasicBlock")	# Name self (line 11)
         self.assertEqual(str(id2type[204]), "NoneType")	# Constant None (line 11)
         self.assertEqual(str(id2type[205]), "NoneType")	# Assign
-        self.assertEqual(str(id2type[206]), "a80")	# Name identity (line 12)
-        self.assertEqual(str(id2type[208]), "a78 (from line 12)")	# Call self.downsample(x) (line 12)
-        self.assertEqual(str(id2type[209]), "torch.Tensor(float32, (1, 64, 56, 56)) -> a78 (from line 12)")	# Attribute self.downsample (line 12)
+        self.assertEqual(str(id2type[206]), "a76 (from line 12)")	# Name identity (line 12)
+        self.assertEqual(str(id2type[208]), "a76 (from line 12)")	# Call self.downsample(x) (line 12)
+        self.assertEqual(str(id2type[209]), "torch.Tensor(float32, (1, 64, 56, 56)) -> a76 (from line 12)")	# Attribute self.downsample (line 12)
         self.assertEqual(str(id2type[210]), "class BasicBlock")	# Name self (line 12)
         self.assertEqual(str(id2type[213]), "torch.Tensor(float32, (1, 64, 56, 56))")	# Name x (line 12)
         self.assertEqual(str(id2type[215]), "NoneType")	# AugAssign
@@ -188,9 +188,9 @@ class TestResNet(unittest.TestCase):
         self.assertEqual(str(id2type[298]), "class BasicBlock")	# Name self (line 11)
         self.assertEqual(str(id2type[302]), "NoneType")	# Constant None (line 11)
         self.assertEqual(str(id2type[303]), "NoneType")	# Assign
-        self.assertEqual(str(id2type[304]), "a126")	# Name identity (line 12)
-        self.assertEqual(str(id2type[306]), "a124 (from line 12)")	# Call self.downsample(x) (line 12)
-        self.assertEqual(str(id2type[307]), "torch.Tensor(float32, (1, 128, 28, 28)) -> a124 (from line 12)")	# Attribute self.downsample (line 12)
+        self.assertEqual(str(id2type[304]), "a120 (from line 12)")	# Name identity (line 12)
+        self.assertEqual(str(id2type[306]), "a120 (from line 12)")	# Call self.downsample(x) (line 12)
+        self.assertEqual(str(id2type[307]), "torch.Tensor(float32, (1, 128, 28, 28)) -> a120 (from line 12)")	# Attribute self.downsample (line 12)
         self.assertEqual(str(id2type[308]), "class BasicBlock")	# Name self (line 12)
         self.assertEqual(str(id2type[311]), "torch.Tensor(float32, (1, 128, 28, 28))")	# Name x (line 12)
         self.assertEqual(str(id2type[313]), "NoneType")	# AugAssign
@@ -245,9 +245,9 @@ class TestResNet(unittest.TestCase):
         self.assertEqual(str(id2type[396]), "class BasicBlock")	# Name self (line 11)
         self.assertEqual(str(id2type[400]), "NoneType")	# Constant None (line 11)
         self.assertEqual(str(id2type[401]), "NoneType")	# Assign
-        self.assertEqual(str(id2type[402]), "a172")	# Name identity (line 12)
-        self.assertEqual(str(id2type[404]), "a170 (from line 12)")	# Call self.downsample(x) (line 12)
-        self.assertEqual(str(id2type[405]), "torch.Tensor(float32, (1, 256, 14, 14)) -> a170 (from line 12)")	# Attribute self.downsample (line 12)
+        self.assertEqual(str(id2type[402]), "a164 (from line 12)")	# Name identity (line 12)
+        self.assertEqual(str(id2type[404]), "a164 (from line 12)")	# Call self.downsample(x) (line 12)
+        self.assertEqual(str(id2type[405]), "torch.Tensor(float32, (1, 256, 14, 14)) -> a164 (from line 12)")	# Attribute self.downsample (line 12)
         self.assertEqual(str(id2type[406]), "class BasicBlock")	# Name self (line 12)
         self.assertEqual(str(id2type[409]), "torch.Tensor(float32, (1, 256, 14, 14))")	# Name x (line 12)
         self.assertEqual(str(id2type[411]), "NoneType")	# AugAssign
@@ -302,9 +302,9 @@ class TestResNet(unittest.TestCase):
         self.assertEqual(str(id2type[494]), "class BasicBlock")	# Name self (line 11)
         self.assertEqual(str(id2type[498]), "NoneType")	# Constant None (line 11)
         self.assertEqual(str(id2type[499]), "NoneType")	# Assign
-        self.assertEqual(str(id2type[500]), "a218")	# Name identity (line 12)
-        self.assertEqual(str(id2type[502]), "a216 (from line 12)")	# Call self.downsample(x) (line 12)
-        self.assertEqual(str(id2type[503]), "torch.Tensor(float32, (1, 512, 7, 7)) -> a216 (from line 12)")	# Attribute self.downsample (line 12)
+        self.assertEqual(str(id2type[500]), "a208 (from line 12)")	# Name identity (line 12)
+        self.assertEqual(str(id2type[502]), "a208 (from line 12)")	# Call self.downsample(x) (line 12)
+        self.assertEqual(str(id2type[503]), "torch.Tensor(float32, (1, 512, 7, 7)) -> a208 (from line 12)")	# Attribute self.downsample (line 12)
         self.assertEqual(str(id2type[504]), "class BasicBlock")	# Name self (line 12)
         self.assertEqual(str(id2type[507]), "torch.Tensor(float32, (1, 512, 7, 7))")	# Name x (line 12)
         self.assertEqual(str(id2type[509]), "NoneType")	# AugAssign


### PR DESCRIPTION
Currently, a type of a list changes in a program when updated.
```
x = [1, 2, 3] # x : [int, int, int]
x.append(4)   # x : int list
```
(cf. https://github.com/pfnet-research/chainer-compiler/compare/master...momohatt:list-invariant?expand=1#diff-5c356c79d973908cc78cef75c3d6ed41L526-L527 )
However, because Python lists are mutable, such changes to types can ruin the soundness when alias analysis is not present.
This PR fixes this problem by fixating the type of lists in a program as follows.
```
x = [1, 2, 3] # x : int list <- not '[int, int, int]'
x.append(4)   # x : int list

y = [1,2]      # y : optional(int) list
y.append(None) # y : optional(int) list
```