### PR TITLE
Fix type inference for dictionaries

### DIFF
--- a/chainer_compiler/elichika/typing/type_inference.py
+++ b/chainer_compiler/elichika/typing/type_inference.py
@@ -695,9 +695,7 @@ class InferenceEngine():
             return TyDict(TyVar(), TyVar())
         ty_keys = [self.infer_expr(key) for key in node.keys]
         ty_vals = [self.infer_expr(val) for val in node.values]
-        assert all_same_ty(ty_keys)
-        assert all_same_ty(ty_vals)
-        return TyDict(ty_keys[0], ty_vals[0])
+        return TyDict(joins(ty_keys), joins(ty_vals))
 
 
     def infer_ListComp(self, node):

--- a/chainer_compiler/elichika/typing/types.py
+++ b/chainer_compiler/elichika/typing/types.py
@@ -14,11 +14,11 @@ __all__ = [ 'TyObj', 'TyNone', 'TyNum', 'TyBool', 'TyInt', 'TyFloat'
           , 'TyDict', 'TyUserDefinedClass', 'TyDType', 'TyVar', 'TyOptional'
           , 'TyTensor', 'TensorKind'
           , 'TyNdarray', 'TyChainerVariable', 'TyTorchTensor'
-          , 'torch_dtype_to_np_dtype', 'all_same_ty'
+          , 'torch_dtype_to_np_dtype'
           , 'type_of_value', 'extract_value_from_ty'
           , 'lacks_value', 'generate_dummy_value', 'tyobj_to_dtype', 'dtype_to_tyobj'
           , 'copy_ty'
-          , 'unify', 'UnifyError', 'join', 'JoinError'
+          , 'unify', 'UnifyError', 'join', 'JoinError', 'joins'
           , 'match_types', 'MatchFail', 'apply_subst'
           ]
 
@@ -188,9 +188,7 @@ class TySequence(TyObj):
     def get(self):
         # get one type as a representative
         if self.is_fixed_len:
-            ty = TyVar()
-            for t in self._ty:
-                ty = join(ty, t)
+            ty = joins(self._ty)
             return ty.deref()
         return self.get_ty()
 
@@ -404,13 +402,6 @@ class TyVar(TyObj):
 
 
 # ------------------------------------------------------------------------------
-
-def all_same_ty(tys):
-    _tytmp = TyVar()
-    for t in tys:
-        unify(_tytmp, t)
-    return True
-
 
 def type_of_value(value):
     if value is None:
@@ -678,9 +669,11 @@ def unify(ty1, ty2):
         return
 
     if isinstance(ty1, TyDict) and isinstance(ty2, TyDict):
-        unify(ty1.keyty, ty2.keyty)
-        unify(ty1.valty, ty2.valty)
-        return
+        keyty = unify(ty1.keyty, ty2.keyty)
+        valty = unify(ty1.valty, ty2.valty)
+        ty1.keyty = ty2.keyty = keyty
+        ty1.valty = ty2.valty = valty
+        return TyDict(keyty, valty)
 
     if isinstance(ty1, TyTensor) and isinstance(ty2, TyTensor):
         utils.set_attr_if_None(ty1, ty2, 'kind')
@@ -793,6 +786,10 @@ def join(ty1, ty2):
             return TyUserDefinedClass(ty1.name, ty1.instance)
 
     raise JoinError(ty1, ty2)
+
+
+def joins(tys):
+    return utils.foldl(join, TyVar(), tys)
 
 
 

--- a/chainer_compiler/elichika/typing/utils.py
+++ b/chainer_compiler/elichika/typing/utils.py
@@ -138,3 +138,9 @@ def set_attr_if_None(obj1, obj2, attr_name):
 
 def all_same(l):
     return all([e == l[0] for e in l])
+
+
+def foldl(fn, acc, l):
+    for x in l:
+        acc = fn(acc, x)
+    return acc

--- a/tests/elichika_typing/Primitive_test.py
+++ b/tests/elichika_typing/Primitive_test.py
@@ -364,6 +364,22 @@ class TestOtherDataTypes(unittest.TestCase):
         self.assertEqual(str(id2type[18]), "string")	# Str (line 3)
 
 
+    def test_dict_optional(self):
+        class Test():
+            def forward(self):
+                return {'foo': 1, 'bar': None}
+
+        id2type = generate_id2type_from_forward(Test(), ())
+
+        self.assertEqual(str(id2type[1]), "class Test -> {string : optional(int)}")	# FunctionDef forward (line 1)
+        self.assertEqual(str(id2type[5]), "{string : optional(int)}")	# Return
+        self.assertEqual(str(id2type[6]), "{string : optional(int)}")	# Dict  (line 2)
+        self.assertEqual(str(id2type[7]), "string")	# Constant 'hoge' (line 2)
+        self.assertEqual(str(id2type[8]), "string")	# Constant 'fuga' (line 2)
+        self.assertEqual(str(id2type[9]), "int")	# Constant 1 (line 2)
+        self.assertEqual(str(id2type[10]), "NoneType")	# Constant None (line 2)
+
+
     def test_optional(self):
         class Test():
             def forward(self):


### PR DESCRIPTION
The inference results of a dictionary `{'foo': 1, 'bar': None}` has been `{string : int}` whereas it is expected to be `{string : optional(int)}`. This PR fixes such wrong behavior.