### PR TITLE
Fix unify to prohibit upcasting of types

### DIFF
--- a/chainer_compiler/elichika/typing/shape_elem.py
+++ b/chainer_compiler/elichika/typing/shape_elem.py
@@ -11,6 +11,7 @@ __all__ = [ 'ShapeElem'
           , 'size_of_ShapeElem'
           , 'unify_shape'
           , 'join_shape'
+          , 'is_subshape'
           , 'apply_subst_shape'
           , 'match_shape'
           ]
@@ -262,6 +263,12 @@ def join_shape(shape1, shape2):
         if e1.value == e2.value:
             ret[i] = e1.value
     return ret
+
+
+def is_subshape(shape1, shape2):
+    def is_subShapeElem(e1, e2):
+        return e2.value is None or e1.value == e2.value
+    return all([is_subShapeElem(e1, e2) for e1, e2 in zip(shape1, shape2)])
 
 
 def apply_subst_shapeElem(subst, e):

--- a/chainer_compiler/elichika/typing/type_inference.py
+++ b/chainer_compiler/elichika/typing/type_inference.py
@@ -488,7 +488,7 @@ class InferenceEngine():
             ty_index  = self.infer_expr(target.slice.value).deref()
 
             if isinstance(ty_target, TyList):
-                unify(ty_index, TyInt()) # TODO: Should be a subtype constraint
+                assert is_subtype(ty_index, TyInt())
                 unify(ty_target, TyList(ty_val))
                 return
 

--- a/tests/elichika_typing/Primitive_test.py
+++ b/tests/elichika_typing/Primitive_test.py
@@ -295,58 +295,6 @@ class TestSequence(unittest.TestCase):
         self.assertEqual(str(id2type[36]), "int")	# Name x (line 2)
 
 
-    def test_list_optional(self):
-        class Test():
-            def forward(self):
-                xs = [1, 2]
-                ys = xs
-                xs.append(None)
-                return ys
-
-        id2type = generate_id2type_from_forward(Test(), ())
-
-        self.assertEqual(str(id2type[1]), "class Test -> optional(int) list")	# FunctionDef forward (line 1)
-        self.assertEqual(str(id2type[5]), "NoneType")	# Assign
-        self.assertEqual(str(id2type[6]), "optional(int) list")	# Name xs (line 2)
-        self.assertEqual(str(id2type[8]), "optional(int) list")	# List [1, 2] (line 2)
-        self.assertEqual(str(id2type[9]), "int")	# Constant 1 (line 2)
-        self.assertEqual(str(id2type[10]), "int")	# Constant 2 (line 2)
-        self.assertEqual(str(id2type[12]), "NoneType")	# Assign
-        self.assertEqual(str(id2type[13]), "optional(int) list")	# Name ys (line 3)
-        self.assertEqual(str(id2type[15]), "optional(int) list")	# Name xs (line 3)
-        self.assertEqual(str(id2type[17]), "NoneType")	# Expr
-        self.assertEqual(str(id2type[18]), "NoneType")	# Call xs.append(None) (line 4)
-        self.assertEqual(str(id2type[20]), "optional(int) list")	# Name xs (line 4)
-        self.assertEqual(str(id2type[23]), "NoneType")	# Constant None (line 4)
-        self.assertEqual(str(id2type[24]), "optional(int) list")	# Return
-        self.assertEqual(str(id2type[25]), "optional(int) list")	# Name ys (line 5)
-
-
-    def test_list_augassign(self):
-        class Test():
-            def forward(self):
-                l = [1, 2, 3]
-                l[1] += 1.0
-                return l
-
-        id2type = generate_id2type_from_forward(Test(), ())
-
-        self.assertEqual(str(id2type[1]), "class Test -> float list")	# FunctionDef forward (line 1)
-        self.assertEqual(str(id2type[5]), "NoneType")	# Assign
-        self.assertEqual(str(id2type[6]), "float list")	# Name l (line 2)
-        self.assertEqual(str(id2type[8]), "float list")	# List [1, 2, 3] (line 2)
-        self.assertEqual(str(id2type[9]), "int")	# Constant 1 (line 2)
-        self.assertEqual(str(id2type[10]), "int")	# Constant 2 (line 2)
-        self.assertEqual(str(id2type[11]), "int")	# Constant 3 (line 2)
-        self.assertEqual(str(id2type[13]), "NoneType")	# AugAssign
-        self.assertEqual(str(id2type[14]), "float")	# Subscript d[1] (line 3)
-        self.assertEqual(str(id2type[15]), "float list")	# Name l (line 3)
-        self.assertEqual(str(id2type[18]), "int")	# Constant 1 (line 3)
-        self.assertEqual(str(id2type[21]), "float")	# Constant 1.0 (line 3)
-        self.assertEqual(str(id2type[22]), "float list")	# Return
-        self.assertEqual(str(id2type[23]), "float list")	# Name l (line 4)
-
-
 # ==============================================================================
 
 class TestOtherDataTypes(unittest.TestCase):
@@ -412,32 +360,6 @@ class TestOtherDataTypes(unittest.TestCase):
         self.assertEqual(str(id2type[8]), "string")	# Constant 'fuga' (line 2)
         self.assertEqual(str(id2type[9]), "int")	# Constant 1 (line 2)
         self.assertEqual(str(id2type[10]), "NoneType")	# Constant None (line 2)
-
-
-    def test_dict_assign(self):
-        class Test():
-            def forward(self):
-                d = {}
-                d[None] = 0
-                d[1] = 1.0
-                return d
-
-        id2type = generate_id2type_from_forward(Test(), ())
-
-        self.assertEqual(str(id2type[1]), "class Test -> {optional(int) : float}")	# FunctionDef forward (line 1)
-        self.assertEqual(str(id2type[5]), "NoneType")	# Assign
-        self.assertEqual(str(id2type[6]), "{optional(int) : float}")	# Name d (line 2)
-        self.assertEqual(str(id2type[8]), "{optional(int) : float}")	# Dict  (line 2)
-        self.assertEqual(str(id2type[9]), "NoneType")	# Assign
-        self.assertEqual(str(id2type[11]), "{optional(int) : float}")	# Name d (line 3)
-        self.assertEqual(str(id2type[14]), "NoneType")	# Constant None (line 3)
-        self.assertEqual(str(id2type[16]), "float")	# Constant 0 (line 3)
-        self.assertEqual(str(id2type[17]), "NoneType")	# Assign
-        self.assertEqual(str(id2type[19]), "{optional(int) : float}")	# Name d (line 4)
-        self.assertEqual(str(id2type[22]), "int")	# Constant 1 (line 4)
-        self.assertEqual(str(id2type[24]), "float")	# Constant 1.0 (line 4)
-        self.assertEqual(str(id2type[25]), "{optional(int) : float}")	# Return
-        self.assertEqual(str(id2type[26]), "{optional(int) : float}")	# Name d (line 5)
 
 
     def test_optional(self):


### PR DESCRIPTION
This PR fixes the behavior of `unify` so that it only instantiates unassigned `TyVar`s and doesn't try to infer the upcasting of types. As a result, some of the test cases in Primitive_test.py becomes untypeable.

Also, this PR makes list/dict types invariant by adding a subtyping check in `join`.